### PR TITLE
Remove Resque tasks from tasks file

### DIFF
--- a/lib/sidekiq_bus/tasks.rb
+++ b/lib/sidekiq_bus/tasks.rb
@@ -1,8 +1,6 @@
 # require 'sidekiq_bus/tasks'
 # will give you these tasks
 
-
-require "resque/tasks"
 namespace :sidekiqbus do
 
   desc "Setup will configure a resque task to run before resque:work"


### PR DESCRIPTION
Hey @bleonard, 

Exciting news: we are wanting to give SidekiqBus a try on our servers! Unfortunately there is a crufty reference to the old resque tasks. Let me know if and when you can merge this and ideally cut another gem. Thanks!

Jonathan. 
