### PR TITLE
Updates the upper bound on sidekiq

### DIFF
--- a/sidekiq-bus.gemspec
+++ b/sidekiq-bus.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('queue-bus', '0.5.9')
-  s.add_dependency('sidekiq', ['>= 3.0.0', '<= 5.0'])
+  s.add_dependency('sidekiq', ['>= 3.0.0', '~> 5.0'])
 
   s.add_development_dependency("rspec")
   s.add_development_dependency("fakeredis")


### PR DESCRIPTION
The previous bound was <= 5.0, which locked the version to `5.0.0` when
installing the dependency. This means it was lacking the minor versions
and patches. By moving it to ~> 5.0 we allow these smaller versions to
be included.