### PR TITLE
Relaxes the queue-bus version

### DIFF
--- a/sidekiq-bus.gemspec
+++ b/sidekiq-bus.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('queue-bus', '0.5.9')
+  s.add_dependency('queue-bus', '~> 0.6')
   s.add_dependency('sidekiq', ['>= 3.0.0', '~> 5.0'])
 
   s.add_development_dependency("rspec")


### PR DESCRIPTION
To make this more flexible with other queue-bus dependencies, the
version on queue-bus is relaxed.