### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/sidekiq-bus.gemspec
+++ b/sidekiq-bus.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{A simple event bus on top of Sidekiq}
   s.description = %q{A simple event bus on top of Sidekiq. Publish and subscribe to events as they occur through a queue.}
 
-  s.rubyforge_project = "sidekiq-bus"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.