### PR TITLE
Sets adapter only when not set already

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "http://rubygems.org"
 
 gemspec
-
-# gem "queue-bus", path: "../queue-bus"

--- a/lib/sidekiq-bus.rb
+++ b/lib/sidekiq-bus.rb
@@ -43,4 +43,9 @@ module SidekiqBus
   end
 end
 
-QueueBus.adapter = QueueBus::Adapters::Sidekiq.new unless QueueBus.has_adapter?
+if QueueBus.has_adapter?
+  warn '[SidekiqBus] Not setting adapter on queue-bus because ' \
+      "#{QueueBus.adapter.class.name} is already the adapter"
+else
+  QueueBus.adapter = QueueBus::Adapters::Sidekiq.new
+end

--- a/lib/sidekiq-bus.rb
+++ b/lib/sidekiq-bus.rb
@@ -5,8 +5,6 @@ require 'sidekiq_bus/adapter'
 require 'sidekiq_bus/version'
 require 'sidekiq_bus/middleware/retry'
 
-QueueBus.adapter = QueueBus::Adapters::Sidekiq.new
-
 module SidekiqBus
   # This method will analyze the current queues and generate an array that
   # can operate as the sidekiq queues configuration. It should be based on how
@@ -44,3 +42,5 @@ module SidekiqBus
     entries.flat_map { |e| Array.new(e.weight, e.queue) }
   end
 end
+
+QueueBus.adapter = QueueBus::Adapters::Sidekiq.new unless QueueBus.has_adapter?

--- a/sidekiq-bus.gemspec
+++ b/sidekiq-bus.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('queue-bus', ['>= 0.5.9', '< 1'])
+  s.add_dependency('queue-bus', ['>= 0.7', '< 1'])
   s.add_dependency('sidekiq', ['>= 3.0.0', '~> 5.0'])
 
   s.add_development_dependency("rspec")


### PR DESCRIPTION
This change requires that a new version of queue-bus be used and so
changes the dependency as well. It also adds a changelog file to track
changes in.