### PR TITLE
Adds heartbeat to sidekiq bus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 pkg/*
 .DS_Store
+/log/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,35 @@
+AllCops:
+  TargetRubyVersion: 2.4
+  ExtraDetails: true
+
+# http://rubocop.readthedocs.io/en/latest/cops_style/#stylefrozenstringliteralcomment
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
+# https://rubocop.readthedocs.io/en/latest/cops_style/#styledatetime
+Style/DateTime:
+  Enabled: true
+
+# http://rubocop.readthedocs.io/en/latest/cops_metrics/#metricslinelength
+Metrics/LineLength:
+  Max: 100
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
+# https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutdotposition
+Layout/DotPosition:
+  Enabled: true
+  EnforcedStyle: leading
+
+# https://rubocop.readthedocs.io/en/latest/cops_style/#stylehashsyntax
+Style/HashSyntax:
+  Enabled: true
+
+# https://rubocop-rspec.readthedocs.io/en/latest/cops_rspec/#rspecfocus
+RSpec/Focus:
+  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Adds sidekiq-scheduler as a dependency
+- Sets up the schedule of heartbeats within the adapter.
+
 ## [0.7.0] - 2019-07-29
 
 ### Changed

--- a/lib/sidekiq_bus/adapter.rb
+++ b/lib/sidekiq_bus/adapter.rb
@@ -1,16 +1,22 @@
+# frozen_string_literal: true
+
 module QueueBus
   module Adapters
+    # The sidekiq adapter for queue-bus. It handles enabling, enqueuing, and
+    # setting up the heartbeat.
     class Sidekiq < QueueBus::Adapters::Base
       def enabled!
         # know we are using it
         require 'sidekiq'
 
-        #this sidekiq middleware adds in the 'retry' key to the job payload so we ensure sidekiq plays well with resque
+        # this sidekiq middleware adds in the 'retry' key to the job payload so
+        # we ensure sidekiq plays well with resque.
         ::Sidekiq.configure_server do |config|
           config.client_middleware do |chain|
             chain.prepend ::SidekiqBus::Middleware::Client::Retry
           end
         end
+
         ::QueueBus::Worker.include ::Sidekiq::Worker
       end
 
@@ -19,16 +25,40 @@ module QueueBus
       end
 
       def enqueue(queue_name, klass, hash)
-        ::Sidekiq::Client.push('queue' => queue_name, 'class' => klass, 'args' => [hash])
+        ::Sidekiq::Client.push('queue' => queue_name,
+                               'class' => klass,
+                               'args' => [hash])
       end
 
       def enqueue_at(epoch_seconds, queue_name, klass, hash)
-        ::Sidekiq::Client.push('queue' => queue_name, 'class' => klass, 'args' => [hash], 'at' => epoch_seconds)
+        ::Sidekiq::Client.push('queue' => queue_name,
+                               'class' => klass,
+                               'args' => [hash],
+                               'at' => epoch_seconds)
       end
 
+      # Sets up the heartbeat to be broadcast via sidekiq. Only enable this when
+      # you have disabled the resque heart beat schedule as well, as having both
+      # may cause issues.
+      #
+      # While this will work so long as every time sidekiq boots it triggers this
+      # set up. You may consider enabling dynamic schedules to keep all nodes up
+      # to date if it ever changes.
       def setup_heartbeat!(queue_name)
-        # TODO: not sure how to do this or what is means to set this up in Sidekiq
-        raise NotImplementedError
+        require 'sidekiq-scheduler'
+
+        ::Sidekiq.set_schedule(
+          'sidekiqbus_heartbeat',
+          every: '1min',
+          class: ::QueueBus::Worker.name,
+          args: [
+            ::QueueBus::Util.encode('bus_class_proxy' => ::QueueBus::Heartbeat.name)
+          ],
+          queue: queue_name,
+          description: 'Enqueues a heart beat every minute for the queue-bus'
+        )
+        # Must reload the schedule to make it present in memory
+        ::Sidekiq.reload_schedule!
       end
     end
   end

--- a/sidekiq-bus.gemspec
+++ b/sidekiq-bus.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("pry")
   s.add_development_dependency("timecop")
   s.add_development_dependency("json_pure")
+  s.add_development_dependency("rubocop")
 end

--- a/sidekiq-bus.gemspec
+++ b/sidekiq-bus.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('queue-bus', ['>= 0.7', '< 1'])
   s.add_dependency('sidekiq', ['>= 3.0.0', '~> 5.0'])
+  s.add_dependency('sidekiq-scheduler', '~> 3.0')
 
   s.add_development_dependency("rspec")
   s.add_development_dependency("fakeredis")

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -1,14 +1,54 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-describe "adapter is set" do
+describe 'adapter is set' do
   it "should call it's enabled! method on init" do
     QueueBus.send(:reset)
     expect_any_instance_of(adapter_under_test_class).to receive(:enabled!)
-    instance = adapter_under_test_class.new
+    adapter_under_test_class.new
     QueueBus.send(:reset)
   end
 
-  it "should be defaulting to Data from spec_helper" do
+  it 'should be defaulting to Data from spec_helper' do
     expect(QueueBus.adapter.is_a?(adapter_under_test_class)).to eq(true)
+  end
+
+  describe '.setup_heartbeat!' do
+    context 'when already setup' do
+      before { QueueBus.heartbeat! }
+
+      it 'does not change schedule' do
+        expect { QueueBus.heartbeat! }
+          .not_to(change { Sidekiq.get_schedule('sidekiqbus_heartbeat') })
+      end
+
+      it 'has the schedule for every minute' do
+        expect(Sidekiq.get_schedule('sidekiqbus_heartbeat')['every'])
+          .to eq '1min'
+      end
+
+      it 'has scheduled the queue bus worker' do
+        expect(Sidekiq.get_schedule('sidekiqbus_heartbeat')['class'])
+          .to eq ::QueueBus::Worker.name
+      end
+
+      it 'will run the heartbeat proxy' do
+        expect(Sidekiq.get_schedule('sidekiqbus_heartbeat')['args'])
+          .to eq [{ bus_class_proxy: 'QueueBus::Heartbeat' }.to_json]
+      end
+
+      it 'will enqueue to bus_incoming' do
+        expect(Sidekiq.get_schedule('sidekiqbus_heartbeat')['queue'])
+          .to eq 'bus_incoming'
+      end
+    end
+
+    context 'when it does not exist' do
+      it 'sets the schedule' do
+        expect { QueueBus.heartbeat! }
+          .to(change { Sidekiq.get_schedule('sidekiqbus_heartbeat') })
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,18 @@ reset_test_adapter
 require 'fakeredis'
 Sidekiq.redis = ConnectionPool.new { Redis.new(driver: Redis::Connection::Memory) }
 
+require 'fileutils'
+
+# Ensuring log file exist and are ready for running specs.
+log_file = File.join(__dir__, '../log/test.log')
+FileUtils.mkdir_p(File.dirname(log_file))
+FileUtils.touch(log_file)
+
+logger = Logger.new(File.open(log_file, 'a'))
+
+Sidekiq.logger = logger
+QueueBus.logger = logger
+
 require 'sidekiq/testing'
 
 module QueueBus


### PR DESCRIPTION
This PR does a couple of things:

* [external facing] Sidekiq bus can now setup a schedule for heartbeats
* Spec logging will now get output to log/test.log
* Rubocop is setup to enforce linting rules