### PR TITLE
Switches heartbeat to cron and cleans up linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Schedule now uses cron format to schedule heartbeat. The "every: 1min" format was causing multiple heartbeats to fire in the same minute if there were multiple sidekiq processes with the dynamic setting turned off (which is default).
+
 ### [0.8.1] - 2019-08-05
 
 ### Fixed

--- a/lib/sidekiq_bus/adapter.rb
+++ b/lib/sidekiq_bus/adapter.rb
@@ -57,7 +57,7 @@ module QueueBus
       def set_schedule(queue_name)
         ::Sidekiq.set_schedule(
           'sidekiqbus_heartbeat',
-          every: '1min',
+          cron: '0 * * * * *', # Runs every minute
           class: ::QueueBus::Worker.name,
           args: [
             ::QueueBus::Util.encode('bus_class_proxy' => ::QueueBus::Heartbeat.name)

--- a/lib/sidekiq_bus/middleware/retry.rb
+++ b/lib/sidekiq_bus/middleware/retry.rb
@@ -1,18 +1,18 @@
+# frozen_string_literal: true
+
 module SidekiqBus
   module Middleware
     module Client
-     
       # ensure sidekiq will retry jobs even when they are enqueued via other adapters
       class Retry
-       def call(worker_class, job, queue, redis_pool)
-         if job['class'] == 'QueueBus::Worker'
-          job['retry'] = true unless job.has_key?('retry')
-          job['backtrace'] = true unless job.has_key?('backtrace')
-         end
-         yield
-       end
+        def call(_worker_class, job, _queue, _redis_pool)
+          if job['class'] == 'QueueBus::Worker'
+            job['retry'] = true unless job.key?('retry')
+            job['backtrace'] = true unless job.key?('backtrace')
+          end
+          yield
+        end
      end
-
    end
  end
 end

--- a/lib/sidekiq_bus/tasks.rb
+++ b/lib/sidekiq_bus/tasks.rb
@@ -1,13 +1,13 @@
+# frozen_string_literal: true
+
 # require 'sidekiq_bus/tasks'
 # will give you these tasks
 
-require "queue_bus/tasks"
+require 'queue_bus/tasks'
 
 namespace :queuebus do
-
   # Preload app files if this is Rails
   task :preload do
-    require "sidekiq"
+    require 'sidekiq'
   end
-
 end

--- a/lib/sidekiq_bus/version.rb
+++ b/lib/sidekiq_bus/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SidekiqBus
-  VERSION = "0.8.1"
+  VERSION = '0.8.1'
 end

--- a/spec/adapter/integration_spec.rb
+++ b/spec/adapter/integration_spec.rb
@@ -53,7 +53,7 @@ describe "Sidekiq Integration" do
     end
     let(:delayed_attrs) { {"bus_delayed_until" => future.to_i,
                        "bus_id" => "#{now.to_i}-idfhlkj",
-                       "bus_app_hostname" =>  `hostname 2>&1`.strip.sub(/.local/,'')} }
+                       "bus_app_hostname" =>  Socket.gethostname} }
 
     let(:bus_attrs) { delayed_attrs.merge({"bus_published_at" => worktime.to_i})}
     let(:now)    { Time.parse("01/01/2013 5:00")}

--- a/spec/adapter/integration_spec.rb
+++ b/spec/adapter/integration_spec.rb
@@ -1,15 +1,15 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
-if Sidekiq::VERSION < '4'
-  require 'celluloid'
-end
+require 'celluloid' if Sidekiq::VERSION < '4'
 require 'sidekiq/scheduled'
 
-describe "Sidekiq Integration" do
-  describe "Happy Path" do
+describe 'Sidekiq Integration' do
+  describe 'Happy Path' do
     before(:each) do
       Sidekiq::Testing.fake!
-      QueueBus.dispatch("r1") do
-        subscribe "event_name" do |attributes|
+      QueueBus.dispatch('r1') do
+        subscribe 'event_name' do |attributes|
           QueueBus::Runner1.run(attributes)
         end
       end
@@ -17,11 +17,11 @@ describe "Sidekiq Integration" do
       QueueBus::TaskManager.new(false).subscribe!
     end
 
-    it "should publish and receive" do
+    it 'should publish and receive' do
       Sidekiq::Testing.fake!
       expect(QueueBus::Runner1.value).to eq(0)
 
-      QueueBus.publish("event_name", "ok" => true)
+      QueueBus.publish('event_name', 'ok' => true)
       expect(QueueBus::Runner1.value).to eq(0)
 
       QueueBus::Worker.perform_one
@@ -33,58 +33,59 @@ describe "Sidekiq Integration" do
       expect(QueueBus::Runner1.value).to eq(1)
     end
 
-    it "should publish and receive" do
+    it 'should publish and receive' do
       Sidekiq::Testing.inline!
       expect(QueueBus::Runner1.value).to eq(0)
 
-      QueueBus.publish("event_name", "ok" => true)
+      QueueBus.publish('event_name', 'ok' => true)
       expect(QueueBus::Runner1.value).to eq(1)
     end
-
   end
 
-  describe "Delayed Publishing" do
+  describe 'Delayed Publishing' do
     before(:each) do
       Timecop.freeze(now)
-      allow(QueueBus).to receive(:generate_uuid).and_return("idfhlkj")
+      allow(QueueBus).to receive(:generate_uuid).and_return('idfhlkj')
     end
     after(:each) do
       Timecop.return
     end
-    let(:delayed_attrs) { {"bus_delayed_until" => future.to_i,
-                       "bus_id" => "#{now.to_i}-idfhlkj",
-                       "bus_app_hostname" =>  Socket.gethostname} }
+    let(:delayed_attrs) do
+      { 'bus_delayed_until' => future.to_i,
+        'bus_id' => "#{now.to_i}-idfhlkj",
+        'bus_app_hostname' =>  Socket.gethostname }
+    end
 
-    let(:bus_attrs) { delayed_attrs.merge({"bus_published_at" => worktime.to_i})}
-    let(:now)    { Time.parse("01/01/2013 5:00")}
+    let(:bus_attrs) { delayed_attrs.merge('bus_published_at' => worktime.to_i) }
+    let(:now)    { Time.parse('01/01/2013 5:00') }
     let(:future) { Time.at(now.to_i + 60) }
-    let(:worktime) {Time.at(future.to_i + 1)}
+    let(:worktime) { Time.at(future.to_i + 1) }
 
-    it "should add it to Redis" do
-      hash = {:one => 1, "two" => "here", "id" => 12 }
-      event_name = "event_name"
+    it 'should add it to Redis' do
+      hash = { :one => 1, 'two' => 'here', 'id' => 12 }
+      event_name = 'event_name'
       QueueBus.publish_at(future, event_name, hash)
 
-      val = QueueBus.redis { |redis| redis.zrange("schedule", 0, 1) }.first
+      val = QueueBus.redis { |redis| redis.zrange('schedule', 0, 1) }.first
 
       hash = JSON.parse(val)
 
-      expect(hash["class"]).to eq("QueueBus::Worker")
-      expect(hash["args"].size).to eq(1)
-      expect(JSON.parse(hash["args"].first)).to eq({"bus_class_proxy" => "QueueBus::Publisher", "bus_event_type"=>"event_name", "two"=>"here", "one"=>1, "id" => 12}.merge(delayed_attrs))
-      expect(hash["queue"]).to eq("bus_incoming")
+      expect(hash['class']).to eq('QueueBus::Worker')
+      expect(hash['args'].size).to eq(1)
+      expect(JSON.parse(hash['args'].first)).to eq({ 'bus_class_proxy' => 'QueueBus::Publisher', 'bus_event_type' => 'event_name', 'two' => 'here', 'one' => 1, 'id' => 12 }.merge(delayed_attrs))
+      expect(hash['queue']).to eq('bus_incoming')
     end
 
-    it "should move it to the real queue when processing" do
-      hash = {:one => 1, "two" => "here", "id" => 12 }
-      event_name = "event_name"
+    it 'should move it to the real queue when processing' do
+      hash = { :one => 1, 'two' => 'here', 'id' => 12 }
+      event_name = 'event_name'
 
-      val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
+      val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
       expect(val).to eq(nil)
 
       QueueBus.publish_at(future, event_name, hash)
 
-      val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
+      val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
       expect(val).to eq(nil) # nothing really added
 
       if Sidekiq::VERSION < '4'
@@ -93,7 +94,7 @@ describe "Sidekiq Integration" do
         Sidekiq::Scheduled::Poller.new.enqueue
       end
 
-      val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
+      val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
       expect(val).to eq(nil) # nothing added yet
 
       # process scheduler in future
@@ -104,21 +105,20 @@ describe "Sidekiq Integration" do
           Sidekiq::Scheduled::Poller.new.enqueue
         end
 
-        val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
+        val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
         hash = JSON.parse(val)
-        expect(hash["class"]).to eq("QueueBus::Worker")
-        expect(hash["args"].size).to eq(1)
-        expect(JSON.parse(hash["args"].first)).to eq({"bus_class_proxy" => "QueueBus::Publisher", "bus_event_type"=>"event_name", "two"=>"here", "one"=>1, "id" => 12}.merge(delayed_attrs))
+        expect(hash['class']).to eq('QueueBus::Worker')
+        expect(hash['args'].size).to eq(1)
+        expect(JSON.parse(hash['args'].first)).to eq({ 'bus_class_proxy' => 'QueueBus::Publisher', 'bus_event_type' => 'event_name', 'two' => 'here', 'one' => 1, 'id' => 12 }.merge(delayed_attrs))
 
-       QueueBus::Publisher.perform(JSON.parse(hash["args"].first))
+        QueueBus::Publisher.perform(JSON.parse(hash['args'].first))
 
-       val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
-       hash = JSON.parse(val)
-       expect(hash["class"]).to eq("QueueBus::Worker")
-       expect(hash["args"].size).to eq(1)
-       expect(JSON.parse(hash["args"].first)).to eq({"bus_class_proxy" => "QueueBus::Driver", "bus_event_type"=>"event_name", "two"=>"here", "one"=>1, "id" => 12}.merge(bus_attrs))
+        val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
+        hash = JSON.parse(val)
+        expect(hash['class']).to eq('QueueBus::Worker')
+        expect(hash['args'].size).to eq(1)
+        expect(JSON.parse(hash['args'].first)).to eq({ 'bus_class_proxy' => 'QueueBus::Driver', 'bus_event_type' => 'event_name', 'two' => 'here', 'one' => 1, 'id' => 12 }.merge(bus_attrs))
       end
     end
-
   end
 end

--- a/spec/adapter/support.rb
+++ b/spec/adapter/support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sidekiq-bus'
 
 def reset_test_adapter

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -40,7 +40,8 @@ describe 'adapter is set' do
 
     shared_examples 'a scheduled heartbeat' do
       it 'has the schedule for every minute' do
-        expect(Sidekiq.get_schedule('sidekiqbus_heartbeat')['every']).to eq '1min'
+        expect(Sidekiq.get_schedule('sidekiqbus_heartbeat')['every']).to be_nil
+        expect(Sidekiq.get_schedule('sidekiqbus_heartbeat')['cron']).to eq '0 * * * * *'
       end
 
       it 'has scheduled the queue bus worker' do

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -1,151 +1,151 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module QueueBus
   describe Application do
-    describe ".all" do
-      it "should return empty array when none" do
+    describe '.all' do
+      it 'should return empty array when none' do
         expect(Application.all).to eq([])
       end
-      it "should return registered applications when there are some" do
-        Application.new("One").subscribe(test_list(test_sub("fdksjh")))
-        Application.new("Two").subscribe(test_list(test_sub("fdklhf")))
-        Application.new("Three").subscribe(test_list(test_sub("fkld")))
+      it 'should return registered applications when there are some' do
+        Application.new('One').subscribe(test_list(test_sub('fdksjh')))
+        Application.new('Two').subscribe(test_list(test_sub('fdklhf')))
+        Application.new('Three').subscribe(test_list(test_sub('fkld')))
 
-        expect(Application.all.collect(&:app_key)).to match_array(["one", "two", "three"])
+        expect(Application.all.collect(&:app_key)).to match_array(%w[one two three])
 
-        Application.new("two").unsubscribe
-        expect(Application.all.collect(&:app_key)).to match_array(["one", "three"])
+        Application.new('two').unsubscribe
+        expect(Application.all.collect(&:app_key)).to match_array(%w[one three])
       end
     end
 
-    describe ".new" do
-      it "should have a key" do
-        expect(Application.new("something").app_key).to eq("something")
+    describe '.new' do
+      it 'should have a key' do
+        expect(Application.new('something').app_key).to eq('something')
 
-        expect(Application.new("some thing").app_key).to eq("some_thing")
-        expect(Application.new("some-thing").app_key).to eq("some_thing")
-        expect(Application.new("some_thing").app_key).to eq("some_thing")
-        expect(Application.new("Some Thing").app_key).to eq("some_thing")
+        expect(Application.new('some thing').app_key).to eq('some_thing')
+        expect(Application.new('some-thing').app_key).to eq('some_thing')
+        expect(Application.new('some_thing').app_key).to eq('some_thing')
+        expect(Application.new('Some Thing').app_key).to eq('some_thing')
       end
 
-      it "should raise an error if not valid" do
-        expect {
-          Application.new("")
-        }.to raise_error("Invalid application name")
+      it 'should raise an error if not valid' do
+        expect do
+          Application.new('')
+        end.to raise_error('Invalid application name')
 
-        expect {
+        expect do
           Application.new(nil)
-        }.to raise_error("Invalid application name")
+        end.to raise_error('Invalid application name')
 
-        expect {
-          Application.new("/")
-        }.to raise_error("Invalid application name")
+        expect do
+          Application.new('/')
+        end.to raise_error('Invalid application name')
       end
     end
 
-    describe "#read_redis_hash" do
-      it "should handle old and new values" do
-
-        QueueBus.redis { |redis| redis.hset("bus_app:myapp", "new_one", QueueBus::Util.encode("queue_name" => "x", "bus_event_type" => "event_name") ) }
-        QueueBus.redis { |redis| redis.hset("bus_app:myapp", "old_one", "oldqueue_name") }
-        app = Application.new("myapp")
+    describe '#read_redis_hash' do
+      it 'should handle old and new values' do
+        QueueBus.redis { |redis| redis.hset('bus_app:myapp', 'new_one', QueueBus::Util.encode('queue_name' => 'x', 'bus_event_type' => 'event_name')) }
+        QueueBus.redis { |redis| redis.hset('bus_app:myapp', 'old_one', 'oldqueue_name') }
+        app = Application.new('myapp')
         val = app.send(:read_redis_hash)
-        expect(val).to eq({"new_one" => {"queue_name" => "x", "bus_event_type" => "event_name"}, "old_one" => "oldqueue_name"})
+        expect(val).to eq('new_one' => { 'queue_name' => 'x', 'bus_event_type' => 'event_name' }, 'old_one' => 'oldqueue_name')
       end
     end
 
-    describe "#subscribe" do
-      let(:sub1) { test_sub("event_one", "default") }
-      let(:sub2) { test_sub("event_two", "default") }
-      let(:sub3) { test_sub("event_three", "other") }
-      it "should add array to redis" do
-        expect(QueueBus.redis { |redis| redis.get("bus_app:myapp") }).to be_nil
-        Application.new("myapp").subscribe(test_list(sub1, sub2))
+    describe '#subscribe' do
+      let(:sub1) { test_sub('event_one', 'default') }
+      let(:sub2) { test_sub('event_two', 'default') }
+      let(:sub3) { test_sub('event_three', 'other') }
+      it 'should add array to redis' do
+        expect(QueueBus.redis { |redis| redis.get('bus_app:myapp') }).to be_nil
+        Application.new('myapp').subscribe(test_list(sub1, sub2))
 
-        expect(QueueBus.redis { |redis| redis.hgetall("bus_app:myapp") }).to eq({"event_two"=>"{\"queue_name\":\"default\",\"key\":\"event_two\",\"class\":\"::QueueBus::Rider\",\"matcher\":{\"bus_event_type\":\"event_two\"}}",
-                                                                  "event_one"=>"{\"queue_name\":\"default\",\"key\":\"event_one\",\"class\":\"::QueueBus::Rider\",\"matcher\":{\"bus_event_type\":\"event_one\"}}"})
-        expect(QueueBus.redis { |redis| redis.hkeys("bus_app:myapp") }).to match_array(["event_one", "event_two"])
-        expect(QueueBus.redis { |redis| redis.smembers("bus_apps") }).to match_array(["myapp"])
+        expect(QueueBus.redis { |redis| redis.hgetall('bus_app:myapp') }).to eq('event_two' => '{"queue_name":"default","key":"event_two","class":"::QueueBus::Rider","matcher":{"bus_event_type":"event_two"}}',
+                                                                                'event_one' => '{"queue_name":"default","key":"event_one","class":"::QueueBus::Rider","matcher":{"bus_event_type":"event_one"}}')
+        expect(QueueBus.redis { |redis| redis.hkeys('bus_app:myapp') }).to match_array(%w[event_one event_two])
+        expect(QueueBus.redis { |redis| redis.smembers('bus_apps') }).to match_array(['myapp'])
       end
-      it "should add string to redis" do
-        expect(QueueBus.redis { |redis| redis.get("bus_app:myapp") }).to be_nil
-        Application.new("myapp").subscribe(test_list(sub1))
+      it 'should add string to redis' do
+        expect(QueueBus.redis { |redis| redis.get('bus_app:myapp') }).to be_nil
+        Application.new('myapp').subscribe(test_list(sub1))
 
-        expect(QueueBus.redis { |redis| redis.hgetall("bus_app:myapp") }).to eq({"event_one"=>"{\"queue_name\":\"default\",\"key\":\"event_one\",\"class\":\"::QueueBus::Rider\",\"matcher\":{\"bus_event_type\":\"event_one\"}}"})
-        expect(QueueBus.redis { |redis| redis.hkeys("bus_app:myapp") }).to match_array(["event_one"])
-        expect(QueueBus.redis { |redis| redis.smembers("bus_apps") }).to match_array(["myapp"])
+        expect(QueueBus.redis { |redis| redis.hgetall('bus_app:myapp') }).to eq('event_one' => '{"queue_name":"default","key":"event_one","class":"::QueueBus::Rider","matcher":{"bus_event_type":"event_one"}}')
+        expect(QueueBus.redis { |redis| redis.hkeys('bus_app:myapp') }).to match_array(['event_one'])
+        expect(QueueBus.redis { |redis| redis.smembers('bus_apps') }).to match_array(['myapp'])
       end
-      it "should multiple queues to redis" do
-        expect(QueueBus.redis { |redis| redis.get("bus_app:myapp") }).to be_nil
-        Application.new("myapp").subscribe(test_list(sub1, sub2, sub3))
-        expect(QueueBus.redis { |redis| redis.hgetall("bus_app:myapp") }).to eq({"event_two"=>"{\"queue_name\":\"default\",\"key\":\"event_two\",\"class\":\"::QueueBus::Rider\",\"matcher\":{\"bus_event_type\":\"event_two\"}}", "event_one"=>"{\"queue_name\":\"default\",\"key\":\"event_one\",\"class\":\"::QueueBus::Rider\",\"matcher\":{\"bus_event_type\":\"event_one\"}}",
-                                                                  "event_three"=>"{\"queue_name\":\"other\",\"key\":\"event_three\",\"class\":\"::QueueBus::Rider\",\"matcher\":{\"bus_event_type\":\"event_three\"}}"})
-        expect(QueueBus.redis { |redis| redis.hkeys("bus_app:myapp") }).to match_array(["event_three", "event_two", "event_one"])
-        expect(QueueBus.redis { |redis| redis.smembers("bus_apps") }).to match_array(["myapp"])
-      end
-
-      it "should do nothing if nil or empty" do
-
-        expect(QueueBus.redis { |redis| redis.get("bus_app:myapp") }).to be_nil
-
-        Application.new("myapp").subscribe(nil)
-        expect(QueueBus.redis { |redis| redis.get("bus_app:myapp") }).to be_nil
-
-        Application.new("myapp").subscribe([])
-        expect(QueueBus.redis { |redis| redis.get("bus_app:myapp") }).to be_nil
+      it 'should multiple queues to redis' do
+        expect(QueueBus.redis { |redis| redis.get('bus_app:myapp') }).to be_nil
+        Application.new('myapp').subscribe(test_list(sub1, sub2, sub3))
+        expect(QueueBus.redis { |redis| redis.hgetall('bus_app:myapp') }).to eq('event_two' => '{"queue_name":"default","key":"event_two","class":"::QueueBus::Rider","matcher":{"bus_event_type":"event_two"}}', 'event_one' => '{"queue_name":"default","key":"event_one","class":"::QueueBus::Rider","matcher":{"bus_event_type":"event_one"}}',
+                                                                                'event_three' => '{"queue_name":"other","key":"event_three","class":"::QueueBus::Rider","matcher":{"bus_event_type":"event_three"}}')
+        expect(QueueBus.redis { |redis| redis.hkeys('bus_app:myapp') }).to match_array(%w[event_three event_two event_one])
+        expect(QueueBus.redis { |redis| redis.smembers('bus_apps') }).to match_array(['myapp'])
       end
 
-      it "should call unsubscribe" do
-        app = Application.new("myapp")
+      it 'should do nothing if nil or empty' do
+        expect(QueueBus.redis { |redis| redis.get('bus_app:myapp') }).to be_nil
+
+        Application.new('myapp').subscribe(nil)
+        expect(QueueBus.redis { |redis| redis.get('bus_app:myapp') }).to be_nil
+
+        Application.new('myapp').subscribe([])
+        expect(QueueBus.redis { |redis| redis.get('bus_app:myapp') }).to be_nil
+      end
+
+      it 'should call unsubscribe' do
+        app = Application.new('myapp')
         expect(app).to receive(:unsubscribe)
         app.subscribe([])
       end
     end
 
-    describe "#unsubscribe" do
-      it "should remove items" do
-        QueueBus.redis { |redis| redis.sadd("bus_apps", "myapp") }
-        QueueBus.redis { |redis| redis.sadd("bus_apps", "other") }
-        QueueBus.redis { |redis| redis.hset("bus_app:myapp", "event_one", "myapp_default") }
+    describe '#unsubscribe' do
+      it 'should remove items' do
+        QueueBus.redis { |redis| redis.sadd('bus_apps', 'myapp') }
+        QueueBus.redis { |redis| redis.sadd('bus_apps', 'other') }
+        QueueBus.redis { |redis| redis.hset('bus_app:myapp', 'event_one', 'myapp_default') }
 
-        Application.new("myapp").unsubscribe
+        Application.new('myapp').unsubscribe
 
-        expect(QueueBus.redis { |redis| redis.smembers("bus_apps") }).to eq(["other"])
-        expect(QueueBus.redis { |redis| redis.get("bus_app:myapp") }).to be_nil
+        expect(QueueBus.redis { |redis| redis.smembers('bus_apps') }).to eq(['other'])
+        expect(QueueBus.redis { |redis| redis.get('bus_app:myapp') }).to be_nil
       end
     end
 
-    describe "#subscription_matches" do
-      it "should return if it is there" do
-        expect(Application.new("myapp").subscription_matches("bus_event_type"=>"three").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to eq([])
+    describe '#subscription_matches' do
+      it 'should return if it is there' do
+        expect(Application.new('myapp').subscription_matches('bus_event_type' => 'three').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to eq([])
 
-        subs = test_list(test_sub("one_x"), test_sub("one_y"), test_sub("one"), test_sub("two"))
-        Application.new("myapp").subscribe(subs)
-        expect(Application.new("myapp").subscription_matches("bus_event_type"=>"three").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to eq([])
+        subs = test_list(test_sub('one_x'), test_sub('one_y'), test_sub('one'), test_sub('two'))
+        Application.new('myapp').subscribe(subs)
+        expect(Application.new('myapp').subscription_matches('bus_event_type' => 'three').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to eq([])
 
-        expect(Application.new("myapp").subscription_matches("bus_event_type"=>"two").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["myapp", "two", "default", "::QueueBus::Rider"]])
-        expect(Application.new("myapp").subscription_matches("bus_event_type"=>"one").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["myapp", "one", "default", "::QueueBus::Rider"]])
+        expect(Application.new('myapp').subscription_matches('bus_event_type' => 'two').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['myapp', 'two', 'default', '::QueueBus::Rider']])
+        expect(Application.new('myapp').subscription_matches('bus_event_type' => 'one').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['myapp', 'one', 'default', '::QueueBus::Rider']])
       end
 
-      it "should handle * wildcards" do
-        subs = test_list(test_sub("one.+"), test_sub("one"), test_sub("one_.*"), test_sub("two"))
-        Application.new("myapp").subscribe(subs)
-        expect(Application.new("myapp").subscription_matches("bus_event_type"=>"three").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to eq([])
+      it 'should handle * wildcards' do
+        subs = test_list(test_sub('one.+'), test_sub('one'), test_sub('one_.*'), test_sub('two'))
+        Application.new('myapp').subscribe(subs)
+        expect(Application.new('myapp').subscription_matches('bus_event_type' => 'three').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to eq([])
 
-        expect(Application.new("myapp").subscription_matches("bus_event_type"=>"onex").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["myapp", "one.+", "default", "::QueueBus::Rider"]])
-        expect(Application.new("myapp").subscription_matches("bus_event_type"=>"one").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["myapp", "one", "default", "::QueueBus::Rider"]])
-        expect(Application.new("myapp").subscription_matches("bus_event_type"=>"one_x").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["myapp", "one.+","default", "::QueueBus::Rider"], ["myapp", "one_.*", "default", "::QueueBus::Rider"]])
+        expect(Application.new('myapp').subscription_matches('bus_event_type' => 'onex').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['myapp', 'one.+', 'default', '::QueueBus::Rider']])
+        expect(Application.new('myapp').subscription_matches('bus_event_type' => 'one').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['myapp', 'one', 'default', '::QueueBus::Rider']])
+        expect(Application.new('myapp').subscription_matches('bus_event_type' => 'one_x').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['myapp', 'one.+', 'default', '::QueueBus::Rider'], ['myapp', 'one_.*', 'default', '::QueueBus::Rider']])
       end
 
-      it "should handle actual regular expressions" do
-        subs = test_list(test_sub(/one.+/), test_sub("one"), test_sub(/one_.*/), test_sub("two"))
-        Application.new("myapp").subscribe(subs)
-        expect(Application.new("myapp").subscription_matches("bus_event_type"=>"three").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to eq([])
+      it 'should handle actual regular expressions' do
+        subs = test_list(test_sub(/one.+/), test_sub('one'), test_sub(/one_.*/), test_sub('two'))
+        Application.new('myapp').subscribe(subs)
+        expect(Application.new('myapp').subscription_matches('bus_event_type' => 'three').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to eq([])
 
-        expect(Application.new("myapp").subscription_matches("bus_event_type"=>"onex").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["myapp", "(?-mix:one.+)", "default", "::QueueBus::Rider"]])
-        expect(Application.new("myapp").subscription_matches("bus_event_type"=>"donex").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["myapp", "(?-mix:one.+)", "default", "::QueueBus::Rider"]])
-        expect(Application.new("myapp").subscription_matches("bus_event_type"=>"one").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["myapp", "one" ,"default", "::QueueBus::Rider"]])
-        expect(Application.new("myapp").subscription_matches("bus_event_type"=>"one_x").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["myapp", "(?-mix:one.+)", "default", "::QueueBus::Rider"], ["myapp", "(?-mix:one_.*)", "default", "::QueueBus::Rider"]])
+        expect(Application.new('myapp').subscription_matches('bus_event_type' => 'onex').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['myapp', '(?-mix:one.+)', 'default', '::QueueBus::Rider']])
+        expect(Application.new('myapp').subscription_matches('bus_event_type' => 'donex').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['myapp', '(?-mix:one.+)', 'default', '::QueueBus::Rider']])
+        expect(Application.new('myapp').subscription_matches('bus_event_type' => 'one').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['myapp', 'one', 'default', '::QueueBus::Rider']])
+        expect(Application.new('myapp').subscription_matches('bus_event_type' => 'one_x').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['myapp', '(?-mix:one.+)', 'default', '::QueueBus::Rider'], ['myapp', '(?-mix:one_.*)', 'default', '::QueueBus::Rider']])
       end
     end
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,83 +1,80 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module QueueBus
   module Adapters
     class TestOne
-
     end
   end
 end
 
-describe "QueueBus config" do
-  it "should set the default app key" do
+describe 'QueueBus config' do
+  it 'should set the default app key' do
     expect(QueueBus.default_app_key).to eq(nil)
 
-    QueueBus.default_app_key = "my_app"
-    expect(QueueBus.default_app_key).to eq("my_app")
+    QueueBus.default_app_key = 'my_app'
+    expect(QueueBus.default_app_key).to eq('my_app')
 
-    QueueBus.default_app_key = "something here"
-    expect(QueueBus.default_app_key).to eq("something_here")
+    QueueBus.default_app_key = 'something here'
+    expect(QueueBus.default_app_key).to eq('something_here')
   end
 
-  it "should set the default queue" do
+  it 'should set the default queue' do
     expect(QueueBus.default_queue).to eq(nil)
 
-    QueueBus.default_queue = "my_queue"
-    expect(QueueBus.default_queue).to eq("my_queue")
+    QueueBus.default_queue = 'my_queue'
+    expect(QueueBus.default_queue).to eq('my_queue')
   end
 
-  it "should set the local mode" do
+  it 'should set the local mode' do
     expect(QueueBus.local_mode).to eq(nil)
     QueueBus.local_mode = :standalone
     expect(QueueBus.local_mode).to eq(:standalone)
   end
 
-  it "should set the hostname" do
+  it 'should set the hostname' do
     expect(QueueBus.hostname).not_to eq(nil)
-    QueueBus.hostname = "whatever"
-    expect(QueueBus.hostname).to eq("whatever")
+    QueueBus.hostname = 'whatever'
+    expect(QueueBus.hostname).to eq('whatever')
   end
 
-  it "should set before_publish callback" do
-    QueueBus.before_publish = lambda {|attributes| 42 }
+  it 'should set before_publish callback' do
+    QueueBus.before_publish = ->(_attributes) { 42 }
     expect(QueueBus.before_publish_callback({})).to eq(42)
   end
 
-
-  it "should use the default Redis connection" do
+  it 'should use the default Redis connection' do
     expect(QueueBus.redis { |redis| redis }).not_to eq(nil)
   end
 
-  it "should default to given adapter" do
+  it 'should default to given adapter' do
     expect(QueueBus.adapter.is_a?(adapter_under_test_class)).to eq(true)
 
     # and should raise if already set
-    expect {
+    expect do
       QueueBus.adapter = :data
-    }.to raise_error("Adapter already set to QueueBus::Adapters::Sidekiq")
+    end.to raise_error('Adapter already set to QueueBus::Adapters::Sidekiq')
   end
 
-  context "with a fresh load" do
+  context 'with a fresh load' do
     before(:each) do
       QueueBus.send(:reset)
     end
 
-    it "should be able to be set to resque" do
+    it 'should be able to be set to resque' do
       QueueBus.adapter = adapter_under_test_symbol
       expect(QueueBus.adapter.is_a?(adapter_under_test_class)).to eq(true)
 
       # and should raise if already set
-      expect {
+      expect do
         QueueBus.adapter = :data
-      }.to raise_error("Adapter already set to QueueBus::Adapters::Sidekiq")
+      end.to raise_error('Adapter already set to QueueBus::Adapters::Sidekiq')
     end
 
-    it "should be able to be set to something else" do
-
+    it 'should be able to be set to something else' do
       QueueBus.adapter = :test_one
       expect(QueueBus.adapter.is_a?(QueueBus::Adapters::TestOne)).to eq(true)
     end
   end
-
-
 end

--- a/spec/dispatch_spec.rb
+++ b/spec/dispatch_spec.rb
@@ -1,72 +1,71 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module QueueBus
   describe Dispatch do
-    it "should not start with any applications" do
-      expect(Dispatch.new("d").subscriptions.size).to eq(0)
+    it 'should not start with any applications' do
+      expect(Dispatch.new('d').subscriptions.size).to eq(0)
     end
 
-    it "should register code to run and execute it" do
-      dispatch = Dispatch.new("d")
-      dispatch.subscribe("my_event") do |attrs|
+    it 'should register code to run and execute it' do
+      dispatch = Dispatch.new('d')
+      dispatch.subscribe('my_event') do |attrs|
         Runner1.run(attrs)
       end
-      sub = dispatch.subscriptions.key("my_event")
+      sub = dispatch.subscriptions.key('my_event')
       expect(sub.send(:executor).is_a?(Proc)).to eq(true)
 
       expect(Runner.value).to eq(0)
-      dispatch.execute("my_event", {"bus_event_type" => "my_event", "ok" => true})
+      dispatch.execute('my_event', 'bus_event_type' => 'my_event', 'ok' => true)
       expect(Runner1.value).to eq(1)
-      expect(Runner1.attributes).to eq({"bus_event_type" => "my_event", "ok" => true})
+      expect(Runner1.attributes).to eq('bus_event_type' => 'my_event', 'ok' => true)
     end
 
-    it "should not crash if not there" do
-      expect(Dispatch.new("d").execute("fdkjh", "bus_event_type" => "fdkjh")).to eq(nil)
+    it 'should not crash if not there' do
+      expect(Dispatch.new('d').execute('fdkjh', 'bus_event_type' => 'fdkjh')).to eq(nil)
     end
 
-    describe "Top Level" do
+    describe 'Top Level' do
       before(:each) do
-         QueueBus.dispatch("testit") do
-           subscribe "event1" do |attributes|
-             Runner2.run(attributes)
-           end
+        QueueBus.dispatch('testit') do
+          subscribe 'event1' do |attributes|
+            Runner2.run(attributes)
+          end
 
-           subscribe "event2" do
-             Runner2.run({})
-           end
+          subscribe 'event2' do
+            Runner2.run({})
+          end
 
-           high "event3" do
-             Runner2.run({})
-           end
+          high 'event3' do
+            Runner2.run({})
+          end
 
-           low /^patt.+ern/ do
-             Runner.run({})
-           end
-         end
-       end
+          low /^patt.+ern/ do
+            Runner.run({})
+          end
+        end
+      end
 
-      it "should register and run" do
+      it 'should register and run' do
         expect(Runner2.value).to eq(0)
-        QueueBus.dispatcher_execute("testit", "event2", "bus_event_type" => "event2")
+        QueueBus.dispatcher_execute('testit', 'event2', 'bus_event_type' => 'event2')
         expect(Runner2.value).to eq(1)
-        QueueBus.dispatcher_execute("testit", "event1", "bus_event_type" => "event1")
+        QueueBus.dispatcher_execute('testit', 'event1', 'bus_event_type' => 'event1')
         expect(Runner2.value).to eq(2)
-        QueueBus.dispatcher_execute("testit", "event1", "bus_event_type" => "event1")
+        QueueBus.dispatcher_execute('testit', 'event1', 'bus_event_type' => 'event1')
         expect(Runner2.value).to eq(3)
       end
 
-      it "should return the subscriptions" do
-        dispatcher = QueueBus.dispatcher_by_key("testit")
+      it 'should return the subscriptions' do
+        dispatcher = QueueBus.dispatcher_by_key('testit')
         subs = dispatcher.subscriptions.all
-        tuples = subs.collect{ |sub| [sub.key, sub.queue_name]}
-        expect(tuples).to match_array([  ["event1", "testit_default"],
-                            ["event2", "testit_default"],
-                            ["event3", "testit_high"],
-                            [ "(?-mix:^patt.+ern)", "testit_low"]
-                         ])
+        tuples = subs.collect { |sub| [sub.key, sub.queue_name] }
+        expect(tuples).to match_array([%w[event1 testit_default],
+                                       %w[event2 testit_default],
+                                       %w[event3 testit_high],
+                                       ['(?-mix:^patt.+ern)', 'testit_low']])
       end
-
     end
   end
-
 end

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -1,92 +1,94 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module QueueBus
   describe Driver do
     before(:each) do
-      Application.new("app1").subscribe(test_list(test_sub("event1"), test_sub("event2"), test_sub("event3")))
-      Application.new("app2").subscribe(test_list(test_sub("event2","other"), test_sub("event4", "more")))
-      Application.new("app3").subscribe(test_list(test_sub("event[45]"), test_sub("event5"), test_sub("event6")))
+      Application.new('app1').subscribe(test_list(test_sub('event1'), test_sub('event2'), test_sub('event3')))
+      Application.new('app2').subscribe(test_list(test_sub('event2', 'other'), test_sub('event4', 'more')))
+      Application.new('app3').subscribe(test_list(test_sub('event[45]'), test_sub('event5'), test_sub('event6')))
       Timecop.freeze
     end
     after(:each) do
       Timecop.return
     end
 
-    let(:bus_attrs) { {"bus_driven_at" => Time.now.to_i, "bus_rider_class_name"=>"::QueueBus::Rider", "bus_class_proxy" => "::QueueBus::Rider"} }
+    let(:bus_attrs) { { 'bus_driven_at' => Time.now.to_i, 'bus_rider_class_name' => '::QueueBus::Rider', 'bus_class_proxy' => '::QueueBus::Rider' } }
 
-    describe ".subscription_matches" do
-      it "return empty array when none" do
-        expect(Driver.subscription_matches("bus_event_type" => "else").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to eq([])
-        expect(Driver.subscription_matches("bus_event_type" => "event").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to eq([])
+    describe '.subscription_matches' do
+      it 'return empty array when none' do
+        expect(Driver.subscription_matches('bus_event_type' => 'else').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to eq([])
+        expect(Driver.subscription_matches('bus_event_type' => 'event').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to eq([])
       end
-      it "should return a match" do
-        expect(Driver.subscription_matches("bus_event_type" => "event1").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["app1", "event1", "default", "::QueueBus::Rider"]])
-        expect(Driver.subscription_matches("bus_event_type" => "event6").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["app3", "event6", "default", "::QueueBus::Rider"]])
+      it 'should return a match' do
+        expect(Driver.subscription_matches('bus_event_type' => 'event1').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['app1', 'event1', 'default', '::QueueBus::Rider']])
+        expect(Driver.subscription_matches('bus_event_type' => 'event6').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['app3', 'event6', 'default', '::QueueBus::Rider']])
       end
-      it "should match multiple apps" do
-        expect(Driver.subscription_matches("bus_event_type" => "event2").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["app1", "event2", "default", "::QueueBus::Rider"], ["app2", "event2", "other", "::QueueBus::Rider"]])
+      it 'should match multiple apps' do
+        expect(Driver.subscription_matches('bus_event_type' => 'event2').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['app1', 'event2', 'default', '::QueueBus::Rider'], ['app2', 'event2', 'other', '::QueueBus::Rider']])
       end
-      it "should match multiple apps with patterns" do
-        expect(Driver.subscription_matches("bus_event_type" => "event4").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["app3", "event[45]", "default", "::QueueBus::Rider"], ["app2", "event4", "more", "::QueueBus::Rider"]])
+      it 'should match multiple apps with patterns' do
+        expect(Driver.subscription_matches('bus_event_type' => 'event4').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['app3', 'event[45]', 'default', '::QueueBus::Rider'], ['app2', 'event4', 'more', '::QueueBus::Rider']])
       end
-      it "should match multiple events in same app" do
-        expect(Driver.subscription_matches("bus_event_type" => "event5").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["app3", "event[45]", "default", "::QueueBus::Rider"], ["app3", "event5", "default", "::QueueBus::Rider"]])
+      it 'should match multiple events in same app' do
+        expect(Driver.subscription_matches('bus_event_type' => 'event5').collect { |s| [s.app_key, s.key, s.queue_name, s.class_name] }).to match_array([['app3', 'event[45]', 'default', '::QueueBus::Rider'], ['app3', 'event5', 'default', '::QueueBus::Rider']])
       end
     end
 
-    describe ".perform" do
-      let(:attributes) { {"x" => "y"} }
+    describe '.perform' do
+      let(:attributes) { { 'x' => 'y' } }
 
       before(:each) do
-        expect(QueueBus.redis { |redis| redis.smembers("queues") }).to eq([])
-        expect(QueueBus.redis { |redis| redis.lpop("queue:app1_default") }).to be_nil
-        expect(QueueBus.redis { |redis| redis.lpop("queue:app2_default") }).to be_nil
-        expect(QueueBus.redis { |redis| redis.lpop("queue:app3_default") }).to be_nil
+        expect(QueueBus.redis { |redis| redis.smembers('queues') }).to eq([])
+        expect(QueueBus.redis { |redis| redis.lpop('queue:app1_default') }).to be_nil
+        expect(QueueBus.redis { |redis| redis.lpop('queue:app2_default') }).to be_nil
+        expect(QueueBus.redis { |redis| redis.lpop('queue:app3_default') }).to be_nil
       end
 
-      it "should do nothing when empty" do
-        Driver.perform(attributes.merge("bus_event_type" => "else"))
-        expect(QueueBus.redis { |redis| redis.smembers("queues") }).to eq([])
+      it 'should do nothing when empty' do
+        Driver.perform(attributes.merge('bus_event_type' => 'else'))
+        expect(QueueBus.redis { |redis| redis.smembers('queues') }).to eq([])
       end
 
-      it "should queue up the riders in redis" do
-        expect(QueueBus.redis { |redis| redis.lpop("queue:app1_default") }).to be_nil
-        Driver.perform(attributes.merge("bus_event_type" => "event1"))
-        expect(QueueBus.redis { |redis| redis.smembers("queues") }).to match_array(["default"])
+      it 'should queue up the riders in redis' do
+        expect(QueueBus.redis { |redis| redis.lpop('queue:app1_default') }).to be_nil
+        Driver.perform(attributes.merge('bus_event_type' => 'event1'))
+        expect(QueueBus.redis { |redis| redis.smembers('queues') }).to match_array(['default'])
 
-        hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:default") })
-        expect(hash["class"]).to eq("QueueBus::Worker")
-        expect(hash["args"].size).to eq(1)
-        expect(JSON.parse(hash["args"].first)).to eq({"bus_rider_app_key"=>"app1", "x" => "y", "bus_event_type" => "event1", "bus_rider_sub_key"=>"event1", "bus_rider_queue" => "default"}.merge(bus_attrs))
+        hash = JSON.parse(QueueBus.redis { |redis| redis.lpop('queue:default') })
+        expect(hash['class']).to eq('QueueBus::Worker')
+        expect(hash['args'].size).to eq(1)
+        expect(JSON.parse(hash['args'].first)).to eq({ 'bus_rider_app_key' => 'app1', 'x' => 'y', 'bus_event_type' => 'event1', 'bus_rider_sub_key' => 'event1', 'bus_rider_queue' => 'default' }.merge(bus_attrs))
       end
 
-      it "should queue up to multiple" do
-        Driver.perform(attributes.merge("bus_event_type" => "event4"))
-        expect(QueueBus.redis { |redis| redis.smembers("queues") }).to match_array(["default", "more"])
+      it 'should queue up to multiple' do
+        Driver.perform(attributes.merge('bus_event_type' => 'event4'))
+        expect(QueueBus.redis { |redis| redis.smembers('queues') }).to match_array(%w[default more])
 
-        hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:more") })
-        expect(hash["class"]).to eq("QueueBus::Worker")
-        expect(hash["args"].size).to eq(1)
-        expect(JSON.parse(hash["args"].first)).to eq({"bus_rider_app_key"=>"app2", "x" => "y", "bus_event_type" => "event4", "bus_rider_sub_key"=>"event4", "bus_rider_queue" => "more"}.merge(bus_attrs))
+        hash = JSON.parse(QueueBus.redis { |redis| redis.lpop('queue:more') })
+        expect(hash['class']).to eq('QueueBus::Worker')
+        expect(hash['args'].size).to eq(1)
+        expect(JSON.parse(hash['args'].first)).to eq({ 'bus_rider_app_key' => 'app2', 'x' => 'y', 'bus_event_type' => 'event4', 'bus_rider_sub_key' => 'event4', 'bus_rider_queue' => 'more' }.merge(bus_attrs))
 
-        hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:default") })
-        expect(hash["class"]).to eq("QueueBus::Worker")
-        expect(hash["args"].size).to eq(1)
-        expect(JSON.parse(hash["args"].first)).to eq({"bus_rider_app_key"=>"app3", "x" => "y", "bus_event_type" => "event4", "bus_rider_sub_key"=>"event[45]", "bus_rider_queue" => "default"}.merge(bus_attrs))
+        hash = JSON.parse(QueueBus.redis { |redis| redis.lpop('queue:default') })
+        expect(hash['class']).to eq('QueueBus::Worker')
+        expect(hash['args'].size).to eq(1)
+        expect(JSON.parse(hash['args'].first)).to eq({ 'bus_rider_app_key' => 'app3', 'x' => 'y', 'bus_event_type' => 'event4', 'bus_rider_sub_key' => 'event[45]', 'bus_rider_queue' => 'default' }.merge(bus_attrs))
       end
 
-      it "should queue up to the same" do
-        Driver.perform(attributes.merge("bus_event_type" => "event5"))
-        expect(QueueBus.redis { |redis| redis.smembers("queues") }).to match_array(["default"])
+      it 'should queue up to the same' do
+        Driver.perform(attributes.merge('bus_event_type' => 'event5'))
+        expect(QueueBus.redis { |redis| redis.smembers('queues') }).to match_array(['default'])
 
-        expect(QueueBus.redis { |redis| redis.llen("queue:default") }).to eq(2)
+        expect(QueueBus.redis { |redis| redis.llen('queue:default') }).to eq(2)
 
-        pop1 = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:default") })
-        pop2 = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:default") })
+        pop1 = JSON.parse(QueueBus.redis { |redis| redis.lpop('queue:default') })
+        pop2 = JSON.parse(QueueBus.redis { |redis| redis.lpop('queue:default') })
 
-        pargs1 = JSON.parse(pop1["args"].first)
-        pargs2 = JSON.parse(pop2["args"].first)
-        if pargs1["bus_rider_sub_key"] == "event5"
+        pargs1 = JSON.parse(pop1['args'].first)
+        pargs2 = JSON.parse(pop2['args'].first)
+        if pargs1['bus_rider_sub_key'] == 'event5'
           hash1 = pop1
           hash2 = pop2
           args1 = pargs1
@@ -98,11 +100,11 @@ module QueueBus
           args2 = pargs1
         end
 
-        expect(hash1["class"]).to eq("QueueBus::Worker")
-        expect(args1).to eq({"bus_rider_app_key"=>"app3", "x" => "y", "bus_event_type" => "event5", "bus_rider_sub_key"=>"event5", "bus_rider_queue" => "default"}.merge(bus_attrs))
+        expect(hash1['class']).to eq('QueueBus::Worker')
+        expect(args1).to eq({ 'bus_rider_app_key' => 'app3', 'x' => 'y', 'bus_event_type' => 'event5', 'bus_rider_sub_key' => 'event5', 'bus_rider_queue' => 'default' }.merge(bus_attrs))
 
-        expect(hash2["class"]).to eq("QueueBus::Worker")
-        expect(args2).to eq({"bus_rider_app_key"=>"app3", "x" => "y", "bus_event_type" => "event5", "bus_rider_sub_key"=>"event[45]", "bus_rider_queue" => "default"}.merge(bus_attrs))
+        expect(hash2['class']).to eq('QueueBus::Worker')
+        expect(args2).to eq({ 'bus_rider_app_key' => 'app3', 'x' => 'y', 'bus_event_type' => 'event5', 'bus_rider_sub_key' => 'event[45]', 'bus_rider_queue' => 'default' }.merge(bus_attrs))
       end
     end
   end

--- a/spec/heartbeat_spec.rb
+++ b/spec/heartbeat_spec.rb
@@ -1,42 +1,44 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module QueueBus
   describe Heartbeat do
     def now_attributes
       {
-        "epoch_seconds" => (Time.now.to_i / 60) * 60, # rounded
-        "epoch_minutes" => Time.now.to_i / 60,
-        "epoch_hours"   => Time.now.to_i / (60*60),
-        "epoch_days"    => Time.now.to_i / (60*60*24),
-        "minute" => Time.now.min,
-        "hour"   => Time.now.hour,
-        "day"    => Time.now.day,
-        "month"  => Time.now.month,
-        "year"   => Time.now.year,
-        "yday"   => Time.now.yday,
-        "wday"   => Time.now.wday
+        'epoch_seconds' => (Time.now.to_i / 60) * 60, # rounded
+        'epoch_minutes' => Time.now.to_i / 60,
+        'epoch_hours'   => Time.now.to_i / (60 * 60),
+        'epoch_days'    => Time.now.to_i / (60 * 60 * 24),
+        'minute' => Time.now.min,
+        'hour'   => Time.now.hour,
+        'day'    => Time.now.day,
+        'month'  => Time.now.month,
+        'year'   => Time.now.year,
+        'yday'   => Time.now.yday,
+        'wday'   => Time.now.wday
       }
     end
-    
-    it "should publish the current time once" do
-      Timecop.freeze "12/12/2013 12:01:19" do
-        expect(QueueBus).to receive(:publish).with("heartbeat_minutes", now_attributes)
+
+    it 'should publish the current time once' do
+      Timecop.freeze '12/12/2013 12:01:19' do
+        expect(QueueBus).to receive(:publish).with('heartbeat_minutes', now_attributes)
         Heartbeat.perform
       end
-      
-      Timecop.freeze "12/12/2013 12:01:40" do
+
+      Timecop.freeze '12/12/2013 12:01:40' do
         Heartbeat.perform
       end
     end
-    
-    it "should publish a minute later" do
-      Timecop.freeze "12/12/2013 12:01:19" do
-        expect(QueueBus).to receive(:publish).with("heartbeat_minutes", now_attributes)
+
+    it 'should publish a minute later' do
+      Timecop.freeze '12/12/2013 12:01:19' do
+        expect(QueueBus).to receive(:publish).with('heartbeat_minutes', now_attributes)
         Heartbeat.perform
       end
-      
-      Timecop.freeze "12/12/2013 12:02:01" do
-        expect(QueueBus).to receive(:publish).with("heartbeat_minutes", now_attributes)
+
+      Timecop.freeze '12/12/2013 12:02:01' do
+        expect(QueueBus).to receive(:publish).with('heartbeat_minutes', now_attributes)
         Heartbeat.perform
       end
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,53 +1,54 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module QueueBus
-  describe "Integration" do
-    it "should round trip attributes" do      
-      write1 = Subscription.new("default", "key1", "MyClass1", {"bus_event_type" => "event_one"})
-      write2 = Subscription.new("else_ok", "key2", "MyClass2", {"bus_event_type" => /^[ab]here/})  #regex
-    
-      expect(write1.matches?("bus_event_type" => "event_one")).to  eq(true)
-      expect(write1.matches?("bus_event_type" => "event_one1")).to eq(false)
-      expect(write1.matches?("bus_event_type" => "aevent_one")).to eq(false)
-      
-      expect(write2.matches?("bus_event_type" => "ahere")).to eq(true)
-      expect(write2.matches?("bus_event_type" => "bhere")).to eq(true)
-      expect(write2.matches?("bus_event_type" => "qhere")).to eq(false)
-      expect(write2.matches?("bus_event_type" => "abhere")).to eq(false)
-      expect(write2.matches?("bus_event_type" => "[ab]here")).to eq(false)
-    
+  describe 'Integration' do
+    it 'should round trip attributes' do
+      write1 = Subscription.new('default', 'key1', 'MyClass1', 'bus_event_type' => 'event_one')
+      write2 = Subscription.new('else_ok', 'key2', 'MyClass2', 'bus_event_type' => /^[ab]here/) # regex
+
+      expect(write1.matches?('bus_event_type' => 'event_one')).to  eq(true)
+      expect(write1.matches?('bus_event_type' => 'event_one1')).to eq(false)
+      expect(write1.matches?('bus_event_type' => 'aevent_one')).to eq(false)
+
+      expect(write2.matches?('bus_event_type' => 'ahere')).to eq(true)
+      expect(write2.matches?('bus_event_type' => 'bhere')).to eq(true)
+      expect(write2.matches?('bus_event_type' => 'qhere')).to eq(false)
+      expect(write2.matches?('bus_event_type' => 'abhere')).to eq(false)
+      expect(write2.matches?('bus_event_type' => '[ab]here')).to eq(false)
+
       write = SubscriptionList.new
       write.add(write1)
       write.add(write2)
-    
-      app = Application.new("test")
+
+      app = Application.new('test')
       app.subscribe(write)
-    
-      reset_test_adapter  # reset to make sure we read from redis
-      app = Application.new("test")
+
+      reset_test_adapter # reset to make sure we read from redis
+      app = Application.new('test')
       read = app.send(:subscriptions)
-    
+
       expect(read.size).to eq(2)
-      read1 = read.key("key1")
-      read2 = read.key("key2")
+      read1 = read.key('key1')
+      read2 = read.key('key2')
       expect(read1).not_to be_nil
       expect(read2).not_to be_nil
-      
-      expect(read1.queue_name).to eq("default")
-      expect(read1.class_name).to eq("MyClass1")
-      expect(read2.queue_name).to eq("else_ok")
-      expect(read2.class_name).to eq("MyClass2")
-      
-      expect(read1.matches?("bus_event_type" => "event_one")).to  eq(true)
-      expect(read1.matches?("bus_event_type" => "event_one1")).to eq(false)
-      expect(read1.matches?("bus_event_type" => "aevent_one")).to eq(false)
-      
-      expect(read2.matches?("bus_event_type" => "ahere")).to eq(true)
-      expect(read2.matches?("bus_event_type" => "bhere")).to eq(true)
-      expect(read2.matches?("bus_event_type" => "qhere")).to eq(false)
-      expect(read2.matches?("bus_event_type" => "abhere")).to eq(false)
-      expect(read2.matches?("bus_event_type" => "[ab]here")).to eq(false)
-      
+
+      expect(read1.queue_name).to eq('default')
+      expect(read1.class_name).to eq('MyClass1')
+      expect(read2.queue_name).to eq('else_ok')
+      expect(read2.class_name).to eq('MyClass2')
+
+      expect(read1.matches?('bus_event_type' => 'event_one')).to  eq(true)
+      expect(read1.matches?('bus_event_type' => 'event_one1')).to eq(false)
+      expect(read1.matches?('bus_event_type' => 'aevent_one')).to eq(false)
+
+      expect(read2.matches?('bus_event_type' => 'ahere')).to eq(true)
+      expect(read2.matches?('bus_event_type' => 'bhere')).to eq(true)
+      expect(read2.matches?('bus_event_type' => 'qhere')).to eq(false)
+      expect(read2.matches?('bus_event_type' => 'abhere')).to eq(false)
+      expect(read2.matches?('bus_event_type' => '[ab]here')).to eq(false)
     end
   end
 end

--- a/spec/matcher_spec.rb
+++ b/spec/matcher_spec.rb
@@ -1,143 +1,145 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module QueueBus
   describe Matcher do
-    it "should already return false on empty filters" do
+    it 'should already return false on empty filters' do
       matcher = Matcher.new({})
-      expect(matcher.matches?({})).to  eq(false)
+      expect(matcher.matches?({})).to eq(false)
       expect(matcher.matches?(nil)).to  eq(false)
-      expect(matcher.matches?("name" => "val")).to eq(false)
+      expect(matcher.matches?('name' => 'val')).to eq(false)
     end
 
-    it "should not crash if nil inputs" do
-      matcher = Matcher.new("name" => "val")
+    it 'should not crash if nil inputs' do
+      matcher = Matcher.new('name' => 'val')
       expect(matcher.matches?(nil)).to eq(false)
     end
 
-    it "string filter to/from redis" do
-      matcher = Matcher.new("name" => "val")
-      expect(matcher.matches?("name" => "val")).to   eq(true)
-      expect(matcher.matches?("name" => " val")).to  eq(false)
-      expect(matcher.matches?("name" => "zval")).to  eq(false)
+    it 'string filter to/from redis' do
+      matcher = Matcher.new('name' => 'val')
+      expect(matcher.matches?('name' => 'val')).to   eq(true)
+      expect(matcher.matches?('name' => ' val')).to  eq(false)
+      expect(matcher.matches?('name' => 'zval')).to  eq(false)
     end
 
-    it "regex filter" do
-      matcher = Matcher.new("name" => /^[cb]a+t/)
-      expect(matcher.matches?("name" => "cat")).to eq(true)
-      expect(matcher.matches?("name" => "bat")).to eq(true)
-      expect(matcher.matches?("name" => "caaaaat")).to eq(true)
-      expect(matcher.matches?("name" => "ct")).to eq(false)
-      expect(matcher.matches?("name" => "bcat")).to eq(false)
+    it 'regex filter' do
+      matcher = Matcher.new('name' => /^[cb]a+t/)
+      expect(matcher.matches?('name' => 'cat')).to eq(true)
+      expect(matcher.matches?('name' => 'bat')).to eq(true)
+      expect(matcher.matches?('name' => 'caaaaat')).to eq(true)
+      expect(matcher.matches?('name' => 'ct')).to eq(false)
+      expect(matcher.matches?('name' => 'bcat')).to eq(false)
     end
 
-    it "present filter" do
-      matcher = Matcher.new("name" => :present)
-      expect(matcher.matches?("name" => "")).to eq(false)
-      expect(matcher.matches?("name" => "cat")).to eq(true)
-      expect(matcher.matches?("name" => "bear")).to eq(true)
-      expect(matcher.matches?("other" => "bear")).to eq(false)
+    it 'present filter' do
+      matcher = Matcher.new('name' => :present)
+      expect(matcher.matches?('name' => '')).to eq(false)
+      expect(matcher.matches?('name' => 'cat')).to eq(true)
+      expect(matcher.matches?('name' => 'bear')).to eq(true)
+      expect(matcher.matches?('other' => 'bear')).to eq(false)
     end
 
-    it "blank filter" do
-      matcher = Matcher.new("name" => :blank)
-      expect(matcher.matches?("name" => nil)).to eq(true)
-      expect(matcher.matches?("other" => "bear")).to eq(true)
-      expect(matcher.matches?("name" => "")).to eq(true)
-      expect(matcher.matches?("name" => "  ")).to eq(true)
-      expect(matcher.matches?("name" => "bear")).to eq(false)
-      expect(matcher.matches?("name" => "   s ")).to eq(false)
+    it 'blank filter' do
+      matcher = Matcher.new('name' => :blank)
+      expect(matcher.matches?('name' => nil)).to eq(true)
+      expect(matcher.matches?('other' => 'bear')).to eq(true)
+      expect(matcher.matches?('name' => '')).to eq(true)
+      expect(matcher.matches?('name' => '  ')).to eq(true)
+      expect(matcher.matches?('name' => 'bear')).to eq(false)
+      expect(matcher.matches?('name' => '   s ')).to eq(false)
     end
 
-    it "nil filter" do
-      matcher = Matcher.new("name" => :nil)
-      expect(matcher.matches?("name" => nil)).to eq(true)
-      expect(matcher.matches?("other" => "bear")).to eq(true)
-      expect(matcher.matches?("name" => "")).to eq(false)
-      expect(matcher.matches?("name" => "  ")).to eq(false)
-      expect(matcher.matches?("name" => "bear")).to eq(false)
+    it 'nil filter' do
+      matcher = Matcher.new('name' => :nil)
+      expect(matcher.matches?('name' => nil)).to eq(true)
+      expect(matcher.matches?('other' => 'bear')).to eq(true)
+      expect(matcher.matches?('name' => '')).to eq(false)
+      expect(matcher.matches?('name' => '  ')).to eq(false)
+      expect(matcher.matches?('name' => 'bear')).to eq(false)
     end
 
-    it "key filter" do
-      matcher = Matcher.new("name" => :key)
-      expect(matcher.matches?("name" => nil)).to eq(true)
-      expect(matcher.matches?("other" => "bear")).to eq(false)
-      expect(matcher.matches?("name" => "")).to eq(true)
-      expect(matcher.matches?("name" => "  ")).to eq(true)
-      expect(matcher.matches?("name" => "bear")).to eq(true)
+    it 'key filter' do
+      matcher = Matcher.new('name' => :key)
+      expect(matcher.matches?('name' => nil)).to eq(true)
+      expect(matcher.matches?('other' => 'bear')).to eq(false)
+      expect(matcher.matches?('name' => '')).to eq(true)
+      expect(matcher.matches?('name' => '  ')).to eq(true)
+      expect(matcher.matches?('name' => 'bear')).to eq(true)
     end
 
-    it "empty filter" do
-      matcher = Matcher.new("name" => :empty)
-      expect(matcher.matches?("name" => nil)).to eq(false)
-      expect(matcher.matches?("other" => "bear")).to eq(false)
-      expect(matcher.matches?("name" => "")).to eq(true)
-      expect(matcher.matches?("name" => "  ")).to eq(false)
-      expect(matcher.matches?("name" => "bear")).to eq(false)
-      expect(matcher.matches?("name" => "   s ")).to eq(false)
+    it 'empty filter' do
+      matcher = Matcher.new('name' => :empty)
+      expect(matcher.matches?('name' => nil)).to eq(false)
+      expect(matcher.matches?('other' => 'bear')).to eq(false)
+      expect(matcher.matches?('name' => '')).to eq(true)
+      expect(matcher.matches?('name' => '  ')).to eq(false)
+      expect(matcher.matches?('name' => 'bear')).to eq(false)
+      expect(matcher.matches?('name' => '   s ')).to eq(false)
     end
 
-    it "value filter" do
-      matcher = Matcher.new("name" => :value)
-      expect(matcher.matches?("name" => nil)).to eq(false)
-      expect(matcher.matches?("other" => "bear")).to eq(false)
-      expect(matcher.matches?("name" => "")).to eq(true)
-      expect(matcher.matches?("name" => "  ")).to eq(true)
-      expect(matcher.matches?("name" => "bear")).to eq(true)
-      expect(matcher.matches?("name" => "   s ")).to eq(true)
+    it 'value filter' do
+      matcher = Matcher.new('name' => :value)
+      expect(matcher.matches?('name' => nil)).to eq(false)
+      expect(matcher.matches?('other' => 'bear')).to eq(false)
+      expect(matcher.matches?('name' => '')).to eq(true)
+      expect(matcher.matches?('name' => '  ')).to eq(true)
+      expect(matcher.matches?('name' => 'bear')).to eq(true)
+      expect(matcher.matches?('name' => '   s ')).to eq(true)
     end
 
-    it "multiple filters" do
-      matcher = Matcher.new("name" => /^[cb]a+t/, "state" => "sleeping")
-      expect(matcher.matches?("state" => "sleeping", "name" => "cat")).to  eq(true)
-      expect(matcher.matches?("state" => "awake", "name" => "cat")).to     eq(false)
-      expect(matcher.matches?("state" => "sleeping", "name" => "bat")).to  eq(true)
-      expect(matcher.matches?("state" => "sleeping", "name" => "bear")).to eq(false)
-      expect(matcher.matches?("state" => "awake", "name" => "bear")).to    eq(false)
+    it 'multiple filters' do
+      matcher = Matcher.new('name' => /^[cb]a+t/, 'state' => 'sleeping')
+      expect(matcher.matches?('state' => 'sleeping', 'name' => 'cat')).to  eq(true)
+      expect(matcher.matches?('state' => 'awake', 'name' => 'cat')).to     eq(false)
+      expect(matcher.matches?('state' => 'sleeping', 'name' => 'bat')).to  eq(true)
+      expect(matcher.matches?('state' => 'sleeping', 'name' => 'bear')).to eq(false)
+      expect(matcher.matches?('state' => 'awake', 'name' => 'bear')).to    eq(false)
     end
 
-    it "regex should go back and forth into redis" do
-      matcher = Matcher.new("name" => /^[cb]a+t/)
-      expect(matcher.matches?("name" => "cat")).to eq(true)
-      expect(matcher.matches?("name" => "bat")).to eq(true)
-      expect(matcher.matches?("name" => "caaaaat")).to eq(true)
-      expect(matcher.matches?("name" => "ct")).to eq(false)
-      expect(matcher.matches?("name" => "bcat")).to eq(false)
+    it 'regex should go back and forth into redis' do
+      matcher = Matcher.new('name' => /^[cb]a+t/)
+      expect(matcher.matches?('name' => 'cat')).to eq(true)
+      expect(matcher.matches?('name' => 'bat')).to eq(true)
+      expect(matcher.matches?('name' => 'caaaaat')).to eq(true)
+      expect(matcher.matches?('name' => 'ct')).to eq(false)
+      expect(matcher.matches?('name' => 'bcat')).to eq(false)
 
-      QueueBus.redis { |redis| redis.set("temp1", QueueBus::Util.encode(matcher.to_redis) ) }
-      redis = QueueBus.redis { |redis| redis.get("temp1") }
+      QueueBus.redis { |redis| redis.set('temp1', QueueBus::Util.encode(matcher.to_redis)) }
+      redis = QueueBus.redis { |redis| redis.get('temp1') }
       matcher = Matcher.new(QueueBus::Util.decode(redis))
-      expect(matcher.matches?("name" => "cat")).to eq(true)
-      expect(matcher.matches?("name" => "bat")).to eq(true)
-      expect(matcher.matches?("name" => "caaaaat")).to eq(true)
-      expect(matcher.matches?("name" => "ct")).to eq(false)
-      expect(matcher.matches?("name" => "bcat")).to eq(false)
+      expect(matcher.matches?('name' => 'cat')).to eq(true)
+      expect(matcher.matches?('name' => 'bat')).to eq(true)
+      expect(matcher.matches?('name' => 'caaaaat')).to eq(true)
+      expect(matcher.matches?('name' => 'ct')).to eq(false)
+      expect(matcher.matches?('name' => 'bcat')).to eq(false)
 
-      QueueBus.redis { |redis| redis.set("temp2", QueueBus::Util.encode(matcher.to_redis) ) }
-      redis = QueueBus.redis { |redis| redis.get("temp2") }
+      QueueBus.redis { |redis| redis.set('temp2', QueueBus::Util.encode(matcher.to_redis)) }
+      redis = QueueBus.redis { |redis| redis.get('temp2') }
       matcher = Matcher.new(QueueBus::Util.decode(redis))
-      expect(matcher.matches?("name" => "cat")).to eq(true)
-      expect(matcher.matches?("name" => "bat")).to eq(true)
-      expect(matcher.matches?("name" => "caaaaat")).to eq(true)
-      expect(matcher.matches?("name" => "ct")).to eq(false)
-      expect(matcher.matches?("name" => "bcat")).to eq(false)
+      expect(matcher.matches?('name' => 'cat')).to eq(true)
+      expect(matcher.matches?('name' => 'bat')).to eq(true)
+      expect(matcher.matches?('name' => 'caaaaat')).to eq(true)
+      expect(matcher.matches?('name' => 'ct')).to eq(false)
+      expect(matcher.matches?('name' => 'bcat')).to eq(false)
     end
 
-    it "special value should go back and forth into redis" do
-      matcher = Matcher.new("name" => :blank)
-      expect(matcher.matches?("name" => "cat")).to eq(false)
-      expect(matcher.matches?("name" => "")).to    eq(true)
+    it 'special value should go back and forth into redis' do
+      matcher = Matcher.new('name' => :blank)
+      expect(matcher.matches?('name' => 'cat')).to eq(false)
+      expect(matcher.matches?('name' => '')).to    eq(true)
 
-      QueueBus.redis { |redis| redis.set("temp1", QueueBus::Util.encode(matcher.to_redis) ) }
-      redis= QueueBus.redis { |redis| redis.get("temp1") }
+      QueueBus.redis { |redis| redis.set('temp1', QueueBus::Util.encode(matcher.to_redis)) }
+      redis = QueueBus.redis { |redis| redis.get('temp1') }
       matcher = Matcher.new(QueueBus::Util.decode(redis))
-      expect(matcher.matches?("name" => "cat")).to eq(false)
-      expect(matcher.matches?("name" => "")).to    eq(true)
+      expect(matcher.matches?('name' => 'cat')).to eq(false)
+      expect(matcher.matches?('name' => '')).to    eq(true)
 
-      QueueBus.redis { |redis| redis.set("temp2", QueueBus::Util.encode(matcher.to_redis) ) }
-      redis= QueueBus.redis { |redis| redis.get("temp2") }
+      QueueBus.redis { |redis| redis.set('temp2', QueueBus::Util.encode(matcher.to_redis)) }
+      redis = QueueBus.redis { |redis| redis.get('temp2') }
       matcher = Matcher.new(QueueBus::Util.decode(redis))
-      expect(matcher.matches?("name" => "cat")).to eq(false)
-      expect(matcher.matches?("name" => "")).to    eq(true)
+      expect(matcher.matches?('name' => 'cat')).to eq(false)
+      expect(matcher.matches?('name' => '')).to    eq(true)
     end
   end
 end

--- a/spec/publish_spec.rb
+++ b/spec/publish_spec.rb
@@ -1,98 +1,98 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-describe "Publishing an event" do
-
+describe 'Publishing an event' do
   before(:each) do
     Timecop.freeze
-    allow(QueueBus).to receive(:generate_uuid).and_return("idfhlkj")
+    allow(QueueBus).to receive(:generate_uuid).and_return('idfhlkj')
   end
   after(:each) do
     Timecop.return
   end
-  let(:bus_attrs) { {"bus_class_proxy"=>"QueueBus::Driver",
-                     "bus_published_at" => Time.now.to_i,
-                     "bus_id"=>"#{Time.now.to_i}-idfhlkj",
-                     "bus_app_hostname" => Socket.gethostname } }
+  let(:bus_attrs) do
+    { 'bus_class_proxy' => 'QueueBus::Driver',
+      'bus_published_at' => Time.now.to_i,
+      'bus_id' => "#{Time.now.to_i}-idfhlkj",
+      'bus_app_hostname' => Socket.gethostname }
+  end
 
-  it "should add it to Redis" do
-    hash = {:one => 1, "two" => "here", "id" => 12 }
-    event_name = "event_name"
+  it 'should add it to Redis' do
+    hash = { :one => 1, 'two' => 'here', 'id' => 12 }
+    event_name = 'event_name'
 
-    val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
+    val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
     expect(val).to eq(nil)
 
     QueueBus.publish(event_name, hash)
 
-    val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
+    val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
     hash = JSON.parse(val)
-    expect(hash["class"]).to eq("QueueBus::Worker")
-    expect(hash["args"].size).to eq(1)
-    expect(JSON.parse(hash["args"].first)).to eq({"bus_event_type" => event_name, "two"=>"here", "one"=>1, "id" => 12}.merge(bus_attrs))
-
+    expect(hash['class']).to eq('QueueBus::Worker')
+    expect(hash['args'].size).to eq(1)
+    expect(JSON.parse(hash['args'].first)).to eq({ 'bus_event_type' => event_name, 'two' => 'here', 'one' => 1, 'id' => 12 }.merge(bus_attrs))
   end
 
-  it "should use the id if given" do
-    hash = {:one => 1, "two" => "here", "bus_id" => "app-given" }
-    event_name = "event_name"
+  it 'should use the id if given' do
+    hash = { :one => 1, 'two' => 'here', 'bus_id' => 'app-given' }
+    event_name = 'event_name'
 
-    val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
+    val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
     expect(val).to eq(nil)
 
     QueueBus.publish(event_name, hash)
 
-    val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
+    val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
     hash = JSON.parse(val)
-    expect(hash["class"]).to eq("QueueBus::Worker")
-    expect(hash["args"].size).to eq(1)
-    expect(JSON.parse(hash["args"].first)).to eq({"bus_event_type" => event_name, "two"=>"here", "one"=>1}.merge(bus_attrs).merge("bus_id" => 'app-given'))
+    expect(hash['class']).to eq('QueueBus::Worker')
+    expect(hash['args'].size).to eq(1)
+    expect(JSON.parse(hash['args'].first)).to eq({ 'bus_event_type' => event_name, 'two' => 'here', 'one' => 1 }.merge(bus_attrs).merge('bus_id' => 'app-given'))
   end
 
-  it "should add metadata via callback" do
+  it 'should add metadata via callback' do
     myval = 0
     QueueBus.before_publish = lambda { |att|
-      att["mine"] = 4
+      att['mine'] = 4
       myval += 1
     }
 
-    hash = {:one => 1, "two" => "here", "bus_id" => "app-given" }
-    event_name = "event_name"
+    hash = { :one => 1, 'two' => 'here', 'bus_id' => 'app-given' }
+    event_name = 'event_name'
 
-    val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
+    val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
     expect(val).to eq(nil)
 
     QueueBus.publish(event_name, hash)
 
-
-    val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
+    val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
     hash = JSON.parse(val)
-    att = JSON.parse(hash["args"].first)
-    expect(att["mine"]).to eq(4)
+    att = JSON.parse(hash['args'].first)
+    expect(att['mine']).to eq(4)
     expect(myval).to eq(1)
   end
 
-  it "should set the timezone and locale if available" do
+  it 'should set the timezone and locale if available' do
     expect(defined?(I18n)).to be_nil
     expect(Time.respond_to?(:zone)).to eq(false)
 
-    stub_const("I18n", Class.new)
-    allow(I18n).to receive(:locale).and_return("jp")
+    stub_const('I18n', Class.new)
+    allow(I18n).to receive(:locale).and_return('jp')
 
-    allow(Time).to receive(:zone).and_return(double('zone', :name => "EST"))
+    allow(Time).to receive(:zone).and_return(double('zone', name: 'EST'))
 
-    hash = {:one => 1, "two" => "here", "bus_id" => "app-given" }
-    event_name = "event_name"
+    hash = { :one => 1, 'two' => 'here', 'bus_id' => 'app-given' }
+    event_name = 'event_name'
 
-    val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
+    val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
     expect(val).to eq(nil)
 
     QueueBus.publish(event_name, hash)
 
-    val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
+    val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
     hash = JSON.parse(val)
-    expect(hash["class"]).to eq("QueueBus::Worker")
-    att = JSON.parse(hash["args"].first)
-    expect(att["bus_locale"]).to eq("jp")
-    expect(att["bus_timezone"]).to eq("EST")
+    expect(hash['class']).to eq('QueueBus::Worker')
+    att = JSON.parse(hash['args'].first)
+    expect(att['bus_locale']).to eq('jp')
+    expect(att['bus_timezone']).to eq('EST')
   end
-
 end

--- a/spec/publish_spec.rb
+++ b/spec/publish_spec.rb
@@ -12,7 +12,7 @@ describe "Publishing an event" do
   let(:bus_attrs) { {"bus_class_proxy"=>"QueueBus::Driver",
                      "bus_published_at" => Time.now.to_i,
                      "bus_id"=>"#{Time.now.to_i}-idfhlkj",
-                     "bus_app_hostname" =>  `hostname 2>&1`.strip.sub(/.local/,'')} }
+                     "bus_app_hostname" => Socket.gethostname } }
 
   it "should add it to Redis" do
     hash = {:one => 1, "two" => "here", "id" => 12 }

--- a/spec/publisher_spec.rb
+++ b/spec/publisher_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module QueueBus
   describe Publisher do
-    it "should call publish as expected"
+    it 'should call publish as expected'
   end
 end

--- a/spec/rider_spec.rb
+++ b/spec/rider_spec.rb
@@ -1,27 +1,29 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module QueueBus
   describe Rider do
-    it "should call execute" do
+    it 'should call execute' do
       expect(QueueBus).to receive(:dispatcher_execute)
-      Rider.perform("bus_rider_app_key" => "app", "bus_rider_sub_key" => "sub", "ok" => true, "bus_event_type" => "event_name")
+      Rider.perform('bus_rider_app_key' => 'app', 'bus_rider_sub_key' => 'sub', 'ok' => true, 'bus_event_type' => 'event_name')
     end
 
-    it "should change the value" do
-      QueueBus.dispatch("r1") do
-        subscribe "event_name" do |attributes|
+    it 'should change the value' do
+      QueueBus.dispatch('r1') do
+        subscribe 'event_name' do |attributes|
           Runner1.run(attributes)
         end
       end
       expect(Runner1.value).to eq(0)
-      Rider.perform("bus_locale" => "en", "bus_timezone" => "PST", "bus_rider_app_key" => "r1", "bus_rider_sub_key" => "event_name", "ok" => true, "bus_event_type" => "event_name")
-      Rider.perform("bus_rider_app_key" => "other", "bus_rider_sub_key" => "event_name", "ok" => true, "bus_event_type" => "event_name")
+      Rider.perform('bus_locale' => 'en', 'bus_timezone' => 'PST', 'bus_rider_app_key' => 'r1', 'bus_rider_sub_key' => 'event_name', 'ok' => true, 'bus_event_type' => 'event_name')
+      Rider.perform('bus_rider_app_key' => 'other', 'bus_rider_sub_key' => 'event_name', 'ok' => true, 'bus_event_type' => 'event_name')
       expect(Runner1.value).to eq(1)
     end
 
-    it "should set the timezone and locale if present" do
-      QueueBus.dispatch("r1") do
-        subscribe "event_name" do |attributes|
+    it 'should set the timezone and locale if present' do
+      QueueBus.dispatch('r1') do
+        subscribe 'event_name' do |attributes|
           Runner1.run(attributes)
         end
       end
@@ -29,11 +31,11 @@ module QueueBus
       expect(defined?(I18n)).to be_nil
       expect(Time.respond_to?(:zone)).to eq(false)
 
-      stub_const("I18n", Class.new)
-      expect(I18n).to receive(:locale=).with("en")
-      expect(Time).to receive(:zone=).with("PST")
+      stub_const('I18n', Class.new)
+      expect(I18n).to receive(:locale=).with('en')
+      expect(Time).to receive(:zone=).with('PST')
 
-      Rider.perform("bus_locale" => "en", "bus_timezone" => "PST", "bus_rider_app_key" => "r1", "bus_rider_sub_key" => "event_name", "ok" => true, "bus_event_type" => "event_name")
+      Rider.perform('bus_locale' => 'en', 'bus_timezone' => 'PST', 'bus_rider_app_key' => 'r1', 'bus_rider_sub_key' => 'event_name', 'ok' => true, 'bus_event_type' => 'event_name')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'timecop'
 require 'queue-bus'
 require 'adapter/support'
@@ -28,8 +30,8 @@ module QueueBus
       @value ||= 0
     end
 
-    def self.attributes
-      @attributes
+    class << self
+      attr_reader :attributes
     end
 
     def self.run(attrs)
@@ -51,9 +53,9 @@ module QueueBus
   end
 end
 
-def test_sub(event_name, queue="default")
-  matcher = {"bus_event_type" => event_name}
-  QueueBus::Subscription.new(queue, event_name, "::QueueBus::Rider", matcher, nil)
+def test_sub(event_name, queue = 'default')
+  matcher = { 'bus_event_type' => event_name }
+  QueueBus::Subscription.new(queue, event_name, '::QueueBus::Rider', matcher, nil)
 end
 
 def test_list(*args)
@@ -65,7 +67,6 @@ def test_list(*args)
 end
 
 RSpec.configure do |config|
-
   config.run_all_when_everything_filtered = true
   config.filter_run focus: true
   config.alias_example_to :fit, focus: true
@@ -83,8 +84,8 @@ RSpec.configure do |config|
   end
   config.after(:each) do
     begin
-      QueueBus.redis { |redis| redis.flushall }
-    rescue
+      QueueBus.redis(&:flushall)
+    rescue StandardError
     end
     QueueBus.send(:reset)
     QueueBus::Runner1.reset

--- a/spec/subscriber_spec.rb
+++ b/spec/subscriber_spec.rb
@@ -1,270 +1,270 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-  describe QueueBus::Subscriber do
-    let(:attributes) { {"x" => "y"} }
-    let(:bus_attrs) { {"bus_driven_at" => Time.now.to_i} }
+describe QueueBus::Subscriber do
+  let(:attributes) { { 'x' => 'y' } }
+  let(:bus_attrs) { { 'bus_driven_at' => Time.now.to_i } }
 
-    before(:each) do
-      class SubscriberTest1
+  before(:each) do
+    class SubscriberTest1
+      include QueueBus::Subscriber
+      @queue = 'myqueue'
+
+      application :my_thing
+      subscribe :thing_filter, x: 'y'
+      subscribe :event_sub
+
+      def event_sub(attributes)
+        QueueBus::Runner1.run(attributes)
+      end
+
+      def thing_filter(attributes)
+        QueueBus::Runner2.run(attributes)
+      end
+    end
+
+    class SubscriberTest2
+      include QueueBus::Subscriber
+      application :test2
+      subscribe :test2, 'value' => :present
+      transform :make_an_int
+
+      def self.make_an_int(attributes)
+        attributes['value'].to_s.length
+      end
+
+      def test2(int)
+        QueueBus::Runner1.run('transformed' => int)
+      end
+    end
+
+    module SubModule
+      class SubscriberTest3
         include QueueBus::Subscriber
-        @queue = "myqueue"
 
-        application :my_thing
-        subscribe :thing_filter, :x => "y"
-        subscribe :event_sub
+        subscribe_queue :sub_queue1, :test3, bus_event_type: 'the_event'
+        subscribe_queue :sub_queue2, :the_event
+        subscribe :other, bus_event_type: 'other_event'
 
-        def event_sub(attributes)
+        def test3(attributes)
           QueueBus::Runner1.run(attributes)
         end
 
-        def thing_filter(attributes)
+        def the_event(attributes)
           QueueBus::Runner2.run(attributes)
         end
       end
 
-      class SubscriberTest2
+      class SubscriberTest4
         include QueueBus::Subscriber
-        application :test2
-        subscribe :test2,  "value" => :present
-        transform :make_an_int
 
-        def self.make_an_int(attributes)
-          attributes["value"].to_s.length
-        end
-
-        def test2(int)
-          QueueBus::Runner1.run("transformed"=>int)
-        end
+        subscribe_queue :sub_queue1, :test4
       end
-
-      module SubModule
-        class SubscriberTest3
-          include QueueBus::Subscriber
-
-          subscribe_queue :sub_queue1, :test3, :bus_event_type => "the_event"
-          subscribe_queue :sub_queue2, :the_event
-          subscribe :other, :bus_event_type => "other_event"
-
-          def test3(attributes)
-            QueueBus::Runner1.run(attributes)
-          end
-
-          def the_event(attributes)
-            QueueBus::Runner2.run(attributes)
-          end
-        end
-
-        class SubscriberTest4
-          include QueueBus::Subscriber
-
-          subscribe_queue :sub_queue1, :test4
-        end
-      end
-
-      Timecop.freeze
-      QueueBus::TaskManager.new(false).subscribe!
     end
 
-    after(:each) do
-      Timecop.return
+    Timecop.freeze
+    QueueBus::TaskManager.new(false).subscribe!
+  end
+
+  after(:each) do
+    Timecop.return
+  end
+
+  it 'should have the application' do
+    expect(SubscriberTest1.app_key).to eq('my_thing')
+    expect(SubModule::SubscriberTest3.app_key).to eq('sub_module')
+    expect(SubModule::SubscriberTest4.app_key).to eq('sub_module')
+  end
+
+  it 'should be able to transform the attributes' do
+    dispatcher = QueueBus.dispatcher_by_key('test2')
+    all = dispatcher.subscriptions.all
+    expect(all.size).to eq(1)
+
+    sub = all.first
+    expect(sub.queue_name).to eq('test2_default')
+    expect(sub.class_name).to eq('SubscriberTest2')
+    expect(sub.key).to eq('SubscriberTest2.test2')
+    expect(sub.matcher.filters).to eq('value' => 'bus_special_value_present')
+
+    QueueBus::Driver.perform(attributes.merge('bus_event_type' => 'something2', 'value' => 'nice'))
+
+    hash = JSON.parse(QueueBus.redis { |redis| redis.lpop('queue:test2_default') })
+    expect(hash['class']).to eq('QueueBus::Worker')
+    expect(hash['args'].size).to eq(1)
+    expect(JSON.parse(hash['args'].first)).to eq({ 'bus_class_proxy' => 'SubscriberTest2', 'bus_rider_app_key' => 'test2', 'bus_rider_sub_key' => 'SubscriberTest2.test2', 'bus_rider_queue' => 'test2_default', 'bus_rider_class_name' => 'SubscriberTest2',
+                                                   'bus_event_type' => 'something2', 'value' => 'nice', 'x' => 'y' }.merge(bus_attrs))
+
+    expect(QueueBus::Runner1.value).to eq(0)
+    expect(QueueBus::Runner2.value).to eq(0)
+    QueueBus::Util.constantize(hash['class']).perform(*hash['args'])
+    expect(QueueBus::Runner1.value).to eq(1)
+    expect(QueueBus::Runner2.value).to eq(0)
+
+    expect(QueueBus::Runner1.attributes).to eq('transformed' => 4)
+
+    QueueBus::Driver.perform(attributes.merge('bus_event_type' => 'something2', 'value' => '12'))
+
+    hash = JSON.parse(QueueBus.redis { |redis| redis.lpop('queue:test2_default') })
+    expect(hash['class']).to eq('QueueBus::Worker')
+    expect(hash['args'].size).to eq(1)
+    expect(JSON.parse(hash['args'].first)).to eq({ 'bus_class_proxy' => 'SubscriberTest2', 'bus_rider_app_key' => 'test2', 'bus_rider_sub_key' => 'SubscriberTest2.test2', 'bus_rider_queue' => 'test2_default', 'bus_rider_class_name' => 'SubscriberTest2',
+                                                   'bus_event_type' => 'something2', 'value' => '12', 'x' => 'y' }.merge(bus_attrs))
+
+    expect(QueueBus::Runner1.value).to eq(1)
+    expect(QueueBus::Runner2.value).to eq(0)
+    QueueBus::Util.constantize(hash['class']).perform(*hash['args'])
+    expect(QueueBus::Runner1.value).to eq(2)
+    expect(QueueBus::Runner2.value).to eq(0)
+
+    expect(QueueBus::Runner1.attributes).to eq('transformed' => 2)
+  end
+
+  it 'should put in a different queue' do
+    dispatcher = QueueBus.dispatcher_by_key('sub_module')
+    all = dispatcher.subscriptions.all
+    expect(all.size).to eq(4)
+
+    sub = all.select { |s| s.key == 'SubModule::SubscriberTest3.test3' }.first
+    expect(sub.queue_name).to eq('sub_queue1')
+    expect(sub.class_name).to eq('SubModule::SubscriberTest3')
+    expect(sub.key).to eq('SubModule::SubscriberTest3.test3')
+    expect(sub.matcher.filters).to eq('bus_event_type' => 'the_event')
+
+    sub = all.select { |s| s.key == 'SubModule::SubscriberTest3.the_event' }.first
+    expect(sub.queue_name).to eq('sub_queue2')
+    expect(sub.class_name).to eq('SubModule::SubscriberTest3')
+    expect(sub.key).to eq('SubModule::SubscriberTest3.the_event')
+    expect(sub.matcher.filters).to eq('bus_event_type' => 'the_event')
+
+    sub = all.select { |s| s.key == 'SubModule::SubscriberTest3.other' }.first
+    expect(sub.queue_name).to eq('sub_module_default')
+    expect(sub.class_name).to eq('SubModule::SubscriberTest3')
+    expect(sub.key).to eq('SubModule::SubscriberTest3.other')
+    expect(sub.matcher.filters).to eq('bus_event_type' => 'other_event')
+
+    sub = all.select { |s| s.key == 'SubModule::SubscriberTest4.test4' }.first
+    expect(sub.queue_name).to eq('sub_queue1')
+    expect(sub.class_name).to eq('SubModule::SubscriberTest4')
+    expect(sub.key).to eq('SubModule::SubscriberTest4.test4')
+    expect(sub.matcher.filters).to eq('bus_event_type' => 'test4')
+
+    QueueBus::Driver.perform(attributes.merge('bus_event_type' => 'the_event'))
+
+    hash = JSON.parse(QueueBus.redis { |redis| redis.lpop('queue:sub_queue1') })
+    expect(hash['class']).to eq('QueueBus::Worker')
+    expect(hash['args'].size).to eq(1)
+    expect(JSON.parse(hash['args'].first)).to eq({ 'bus_class_proxy' => 'SubModule::SubscriberTest3', 'bus_rider_app_key' => 'sub_module', 'bus_rider_sub_key' => 'SubModule::SubscriberTest3.test3', 'bus_rider_queue' => 'sub_queue1', 'bus_rider_class_name' => 'SubModule::SubscriberTest3',
+                                                   'bus_event_type' => 'the_event', 'x' => 'y' }.merge(bus_attrs))
+
+    expect(QueueBus::Runner1.value).to eq(0)
+    expect(QueueBus::Runner2.value).to eq(0)
+    QueueBus::Util.constantize(hash['class']).perform(*hash['args'])
+    expect(QueueBus::Runner1.value).to eq(1)
+    expect(QueueBus::Runner2.value).to eq(0)
+
+    hash = JSON.parse(QueueBus.redis { |redis| redis.lpop('queue:sub_queue2') })
+    expect(hash['class']).to eq('QueueBus::Worker')
+    expect(hash['args'].size).to eq(1)
+    expect(JSON.parse(hash['args'].first)).to eq({ 'bus_class_proxy' => 'SubModule::SubscriberTest3', 'bus_rider_app_key' => 'sub_module', 'bus_rider_sub_key' => 'SubModule::SubscriberTest3.the_event', 'bus_rider_queue' => 'sub_queue2', 'bus_rider_class_name' => 'SubModule::SubscriberTest3',
+                                                   'bus_event_type' => 'the_event', 'x' => 'y' }.merge(bus_attrs))
+
+    expect(QueueBus::Runner1.value).to eq(1)
+    expect(QueueBus::Runner2.value).to eq(0)
+    QueueBus::Util.constantize(hash['class']).perform(*hash['args'])
+    expect(QueueBus::Runner1.value).to eq(1)
+    expect(QueueBus::Runner2.value).to eq(1)
+  end
+
+  it 'should subscribe to default and attributes' do
+    dispatcher = QueueBus.dispatcher_by_key('my_thing')
+    all = dispatcher.subscriptions.all
+
+    sub = all.select { |s| s.key == 'SubscriberTest1.event_sub' }.first
+    expect(sub.queue_name).to eq('myqueue')
+    expect(sub.class_name).to eq('SubscriberTest1')
+    expect(sub.key).to eq('SubscriberTest1.event_sub')
+    expect(sub.matcher.filters).to eq('bus_event_type' => 'event_sub')
+
+    sub = all.select { |s| s.key == 'SubscriberTest1.thing_filter' }.first
+    expect(sub.queue_name).to eq('myqueue')
+    expect(sub.class_name).to eq('SubscriberTest1')
+    expect(sub.key).to eq('SubscriberTest1.thing_filter')
+    expect(sub.matcher.filters).to eq('x' => 'y')
+
+    QueueBus::Driver.perform(attributes.merge('bus_event_type' => 'event_sub'))
+    expect(QueueBus.redis { |redis| redis.smembers('queues') }).to match_array(['myqueue'])
+
+    pop1 = JSON.parse(QueueBus.redis { |redis| redis.lpop('queue:myqueue') })
+    pop2 = JSON.parse(QueueBus.redis { |redis| redis.lpop('queue:myqueue') })
+
+    if JSON.parse(pop1['args'].first)['bus_rider_sub_key'] == 'SubscriberTest1.thing_filter'
+      hash1 = pop1
+      hash2 = pop2
+    else
+      hash1 = pop2
+      hash2 = pop1
     end
 
-    it "should have the application" do
-      expect(SubscriberTest1.app_key).to eq("my_thing")
-      expect(SubModule::SubscriberTest3.app_key).to eq("sub_module")
-      expect(SubModule::SubscriberTest4.app_key).to eq("sub_module")
+    expect(hash1['class']).to eq('QueueBus::Worker')
+    expect(JSON.parse(hash1['args'].first)).to eq({ 'bus_class_proxy' => 'SubscriberTest1', 'bus_rider_app_key' => 'my_thing', 'bus_rider_sub_key' => 'SubscriberTest1.thing_filter', 'bus_rider_queue' => 'myqueue', 'bus_rider_class_name' => 'SubscriberTest1',
+                                                    'bus_event_type' => 'event_sub', 'x' => 'y' }.merge(bus_attrs))
+
+    expect(QueueBus::Runner1.value).to eq(0)
+    expect(QueueBus::Runner2.value).to eq(0)
+    QueueBus::Util.constantize(hash1['class']).perform(*hash1['args'])
+    expect(QueueBus::Runner1.value).to eq(0)
+    expect(QueueBus::Runner2.value).to eq(1)
+
+    expect(hash2['class']).to eq('QueueBus::Worker')
+    expect(hash2['args'].size).to eq(1)
+    expect(JSON.parse(hash2['args'].first)).to eq({ 'bus_class_proxy' => 'SubscriberTest1', 'bus_rider_app_key' => 'my_thing', 'bus_rider_sub_key' => 'SubscriberTest1.event_sub', 'bus_rider_queue' => 'myqueue', 'bus_rider_class_name' => 'SubscriberTest1',
+                                                    'bus_event_type' => 'event_sub', 'x' => 'y' }.merge(bus_attrs))
+
+    expect(QueueBus::Runner1.value).to eq(0)
+    expect(QueueBus::Runner2.value).to eq(1)
+    QueueBus::Util.constantize(hash2['class']).perform(*hash2['args'])
+    expect(QueueBus::Runner1.value).to eq(1)
+    expect(QueueBus::Runner2.value).to eq(1)
+
+    QueueBus::Driver.perform(attributes.merge('bus_event_type' => 'event_sub_other'))
+    expect(QueueBus.redis { |redis| redis.smembers('queues') }).to match_array(['myqueue'])
+
+    hash = JSON.parse(QueueBus.redis { |redis| redis.lpop('queue:myqueue') })
+    expect(hash['class']).to eq('QueueBus::Worker')
+    expect(hash['args'].size).to eq(1)
+    expect(JSON.parse(hash['args'].first)).to eq({ 'bus_class_proxy' => 'SubscriberTest1', 'bus_rider_app_key' => 'my_thing', 'bus_rider_sub_key' => 'SubscriberTest1.thing_filter', 'bus_rider_queue' => 'myqueue', 'bus_rider_class_name' => 'SubscriberTest1',
+                                                   'bus_event_type' => 'event_sub_other', 'x' => 'y' }.merge(bus_attrs))
+
+    expect(QueueBus::Runner1.value).to eq(1)
+    expect(QueueBus::Runner2.value).to eq(1)
+    QueueBus::Util.constantize(hash['class']).perform(*hash['args'])
+    expect(QueueBus::Runner1.value).to eq(1)
+    expect(QueueBus::Runner2.value).to eq(2)
+
+    QueueBus::Driver.perform({ 'x' => 'z' }.merge('bus_event_type' => 'event_sub_other'))
+    expect(QueueBus.redis { |redis| redis.smembers('queues') }).to match_array(['myqueue'])
+
+    expect(QueueBus.redis { |redis| redis.lpop('queue:myqueue') }).to be_nil
+  end
+
+  describe '.perform' do
+    let(:attributes) { { 'bus_rider_sub_key' => 'SubscriberTest1.event_sub', 'bus_locale' => 'en', 'bus_timezone' => 'PST' } }
+    it 'should call the method based on key' do
+      expect_any_instance_of(SubscriberTest1).to receive(:event_sub)
+      SubscriberTest1.perform(attributes)
     end
+    it 'should set the timezone and locale if present' do
+      expect(defined?(I18n)).to be_nil
+      expect(Time.respond_to?(:zone)).to eq(false)
 
-    it "should be able to transform the attributes" do
-      dispatcher = QueueBus.dispatcher_by_key("test2")
-      all = dispatcher.subscriptions.all
-      expect(all.size).to eq(1)
+      stub_const('I18n', Class.new)
+      expect(I18n).to receive(:locale=).with('en')
+      expect(Time).to receive(:zone=).with('PST')
 
-      sub = all.first
-      expect(sub.queue_name).to eq("test2_default")
-      expect(sub.class_name).to eq("SubscriberTest2")
-      expect(sub.key).to eq("SubscriberTest2.test2")
-      expect(sub.matcher.filters).to eq({"value"=>"bus_special_value_present"})
-
-      QueueBus::Driver.perform(attributes.merge("bus_event_type" => "something2", "value"=>"nice"))
-
-      hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:test2_default") })
-      expect(hash["class"]).to eq("QueueBus::Worker")
-      expect(hash["args"].size).to eq(1)
-      expect(JSON.parse(hash["args"].first)).to eq({"bus_class_proxy" => "SubscriberTest2", "bus_rider_app_key"=>"test2", "bus_rider_sub_key"=>"SubscriberTest2.test2", "bus_rider_queue" => "test2_default", "bus_rider_class_name"=>"SubscriberTest2",
-                               "bus_event_type" => "something2", "value"=>"nice", "x"=>"y"}.merge(bus_attrs))
-
-      expect(QueueBus::Runner1.value).to eq(0)
-      expect(QueueBus::Runner2.value).to eq(0)
-      QueueBus::Util.constantize(hash["class"]).perform(*hash["args"])
-      expect(QueueBus::Runner1.value).to eq(1)
-      expect(QueueBus::Runner2.value).to eq(0)
-
-      expect(QueueBus::Runner1.attributes).to eq({"transformed" => 4})
-
-
-      QueueBus::Driver.perform(attributes.merge("bus_event_type" => "something2", "value"=>"12"))
-
-      hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:test2_default") })
-      expect(hash["class"]).to eq("QueueBus::Worker")
-      expect(hash["args"].size).to eq(1)
-      expect(JSON.parse(hash["args"].first)).to eq({"bus_class_proxy" => "SubscriberTest2", "bus_rider_app_key"=>"test2", "bus_rider_sub_key"=>"SubscriberTest2.test2", "bus_rider_queue" => "test2_default", "bus_rider_class_name"=>"SubscriberTest2",
-                               "bus_event_type" => "something2", "value"=>"12", "x"=>"y"}.merge(bus_attrs))
-
-      expect(QueueBus::Runner1.value).to eq(1)
-      expect(QueueBus::Runner2.value).to eq(0)
-      QueueBus::Util.constantize(hash["class"]).perform(*hash["args"])
-      expect(QueueBus::Runner1.value).to eq(2)
-      expect(QueueBus::Runner2.value).to eq(0)
-
-      expect(QueueBus::Runner1.attributes).to eq({"transformed" => 2})
-    end
-
-
-    it "should put in a different queue" do
-      dispatcher = QueueBus.dispatcher_by_key("sub_module")
-      all = dispatcher.subscriptions.all
-      expect(all.size).to eq(4)
-
-      sub = all.select{ |s| s.key == "SubModule::SubscriberTest3.test3"}.first
-      expect(sub.queue_name).to eq("sub_queue1")
-      expect(sub.class_name).to eq("SubModule::SubscriberTest3")
-      expect(sub.key).to eq("SubModule::SubscriberTest3.test3")
-      expect(sub.matcher.filters).to eq({"bus_event_type"=>"the_event"})
-
-      sub = all.select{ |s| s.key == "SubModule::SubscriberTest3.the_event"}.first
-      expect(sub.queue_name).to eq("sub_queue2")
-      expect(sub.class_name).to eq("SubModule::SubscriberTest3")
-      expect(sub.key).to eq("SubModule::SubscriberTest3.the_event")
-      expect(sub.matcher.filters).to eq({"bus_event_type"=>"the_event"})
-
-      sub = all.select{ |s| s.key == "SubModule::SubscriberTest3.other"}.first
-      expect(sub.queue_name).to eq("sub_module_default")
-      expect(sub.class_name).to eq("SubModule::SubscriberTest3")
-      expect(sub.key).to eq("SubModule::SubscriberTest3.other")
-      expect(sub.matcher.filters).to eq({"bus_event_type"=>"other_event"})
-
-      sub = all.select{ |s| s.key == "SubModule::SubscriberTest4.test4"}.first
-      expect(sub.queue_name).to eq("sub_queue1")
-      expect(sub.class_name).to eq("SubModule::SubscriberTest4")
-      expect(sub.key).to eq("SubModule::SubscriberTest4.test4")
-      expect(sub.matcher.filters).to eq({"bus_event_type"=>"test4"})
-
-      QueueBus::Driver.perform(attributes.merge("bus_event_type" => "the_event"))
-
-      hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:sub_queue1") })
-      expect(hash["class"]).to eq("QueueBus::Worker")
-      expect(hash["args"].size).to eq(1)
-      expect(JSON.parse(hash["args"].first)).to eq({"bus_class_proxy" => "SubModule::SubscriberTest3", "bus_rider_app_key"=>"sub_module", "bus_rider_sub_key"=>"SubModule::SubscriberTest3.test3", "bus_rider_queue" => "sub_queue1", "bus_rider_class_name"=>"SubModule::SubscriberTest3",
-                                "bus_event_type" => "the_event", "x" => "y"}.merge(bus_attrs))
-
-      expect(QueueBus::Runner1.value).to eq(0)
-      expect(QueueBus::Runner2.value).to eq(0)
-      QueueBus::Util.constantize(hash["class"]).perform(*hash["args"])
-      expect(QueueBus::Runner1.value).to eq(1)
-      expect(QueueBus::Runner2.value).to eq(0)
-
-      hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:sub_queue2") })
-      expect(hash["class"]).to eq("QueueBus::Worker")
-      expect(hash["args"].size).to eq(1)
-      expect(JSON.parse(hash["args"].first)).to eq({"bus_class_proxy" => "SubModule::SubscriberTest3", "bus_rider_app_key"=>"sub_module", "bus_rider_sub_key"=>"SubModule::SubscriberTest3.the_event", "bus_rider_queue" => "sub_queue2", "bus_rider_class_name"=>"SubModule::SubscriberTest3",
-                                "bus_event_type" => "the_event", "x" => "y"}.merge(bus_attrs))
-
-      expect(QueueBus::Runner1.value).to eq(1)
-      expect(QueueBus::Runner2.value).to eq(0)
-      QueueBus::Util.constantize(hash["class"]).perform(*hash["args"])
-      expect(QueueBus::Runner1.value).to eq(1)
-      expect(QueueBus::Runner2.value).to eq(1)
-    end
-
-    it "should subscribe to default and attributes" do
-      dispatcher = QueueBus.dispatcher_by_key("my_thing")
-      all = dispatcher.subscriptions.all
-
-      sub = all.select{ |s| s.key == "SubscriberTest1.event_sub"}.first
-      expect(sub.queue_name).to eq("myqueue")
-      expect(sub.class_name).to eq("SubscriberTest1")
-      expect(sub.key).to eq("SubscriberTest1.event_sub")
-      expect(sub.matcher.filters).to eq({"bus_event_type"=>"event_sub"})
-
-      sub = all.select{ |s| s.key == "SubscriberTest1.thing_filter"}.first
-      expect(sub.queue_name).to eq("myqueue")
-      expect(sub.class_name).to eq("SubscriberTest1")
-      expect(sub.key).to eq("SubscriberTest1.thing_filter")
-      expect(sub.matcher.filters).to eq({"x"=>"y"})
-
-      QueueBus::Driver.perform(attributes.merge("bus_event_type" => "event_sub"))
-      expect(QueueBus.redis { |redis| redis.smembers("queues") }).to match_array(["myqueue"])
-
-      pop1 = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:myqueue") })
-      pop2 = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:myqueue") })
-
-      if JSON.parse(pop1["args"].first)["bus_rider_sub_key"] == "SubscriberTest1.thing_filter"
-        hash1 = pop1
-        hash2 = pop2
-      else
-        hash1 = pop2
-        hash2 = pop1
-      end
-
-      expect(hash1["class"]).to eq("QueueBus::Worker")
-      expect(JSON.parse(hash1["args"].first)).to eq({"bus_class_proxy" => "SubscriberTest1", "bus_rider_app_key"=>"my_thing", "bus_rider_sub_key"=>"SubscriberTest1.thing_filter", "bus_rider_queue" => "myqueue", "bus_rider_class_name"=>"SubscriberTest1",
-                                "bus_event_type" => "event_sub", "x" => "y"}.merge(bus_attrs))
-
-      expect(QueueBus::Runner1.value).to eq(0)
-      expect(QueueBus::Runner2.value).to eq(0)
-      QueueBus::Util.constantize(hash1["class"]).perform(*hash1["args"])
-      expect(QueueBus::Runner1.value).to eq(0)
-      expect(QueueBus::Runner2.value).to eq(1)
-
-      expect(hash2["class"]).to eq("QueueBus::Worker")
-      expect(hash2["args"].size).to eq(1)
-      expect(JSON.parse(hash2["args"].first)).to eq({"bus_class_proxy" => "SubscriberTest1", "bus_rider_app_key"=>"my_thing", "bus_rider_sub_key"=>"SubscriberTest1.event_sub", "bus_rider_queue" => "myqueue", "bus_rider_class_name"=>"SubscriberTest1",
-                                "bus_event_type" => "event_sub", "x" => "y"}.merge(bus_attrs))
-
-      expect(QueueBus::Runner1.value).to eq(0)
-      expect(QueueBus::Runner2.value).to eq(1)
-      QueueBus::Util.constantize(hash2["class"]).perform(*hash2["args"])
-      expect(QueueBus::Runner1.value).to eq(1)
-      expect(QueueBus::Runner2.value).to eq(1)
-
-      QueueBus::Driver.perform(attributes.merge("bus_event_type" => "event_sub_other"))
-      expect(QueueBus.redis { |redis| redis.smembers("queues") }).to match_array(["myqueue"])
-
-      hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:myqueue") })
-      expect(hash["class"]).to eq("QueueBus::Worker")
-      expect(hash["args"].size).to eq(1)
-      expect(JSON.parse(hash["args"].first)).to eq({"bus_class_proxy" => "SubscriberTest1", "bus_rider_app_key"=>"my_thing", "bus_rider_sub_key"=>"SubscriberTest1.thing_filter", "bus_rider_queue" => "myqueue", "bus_rider_class_name"=>"SubscriberTest1",
-                                "bus_event_type" => "event_sub_other", "x" => "y"}.merge(bus_attrs))
-
-      expect(QueueBus::Runner1.value).to eq(1)
-      expect(QueueBus::Runner2.value).to eq(1)
-      QueueBus::Util.constantize(hash["class"]).perform(*hash["args"])
-      expect(QueueBus::Runner1.value).to eq(1)
-      expect(QueueBus::Runner2.value).to eq(2)
-
-      QueueBus::Driver.perform({"x"=>"z"}.merge("bus_event_type" => "event_sub_other"))
-      expect(QueueBus.redis { |redis| redis.smembers("queues") }).to match_array(["myqueue"])
-
-      expect(QueueBus.redis { |redis| redis.lpop("queue:myqueue") }).to be_nil
-    end
-
-    describe ".perform" do
-      let(:attributes) { {"bus_rider_sub_key"=>"SubscriberTest1.event_sub", "bus_locale" => "en", "bus_timezone" => "PST"} }
-      it "should call the method based on key" do
-        expect_any_instance_of(SubscriberTest1).to receive(:event_sub)
-        SubscriberTest1.perform(attributes)
-      end
-      it "should set the timezone and locale if present" do
-        expect(defined?(I18n)).to be_nil
-        expect(Time.respond_to?(:zone)).to eq(false)
-
-        stub_const("I18n", Class.new)
-        expect(I18n).to receive(:locale=).with("en")
-        expect(Time).to receive(:zone=).with("PST")
-
-        expect_any_instance_of(SubscriberTest1).to receive(:event_sub)
-        SubscriberTest1.perform(attributes)
-      end
+      expect_any_instance_of(SubscriberTest1).to receive(:event_sub)
+      SubscriberTest1.perform(attributes)
     end
   end
+end

--- a/spec/subscription_list_spec.rb
+++ b/spec/subscription_list_spec.rb
@@ -1,42 +1,42 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module QueueBus
   describe SubscriptionList do
-    describe ".from_redis" do
-      it "should return from attributes" do
-        mult = {"event_one" => {"class" => "MyClass", "queue_name" => "default", "key" => "event_one", "matcher" => {"bus_event_type" => "event_one"}}, 
-                "event_two" => {"class" => "MyClass", "queue_name" => "else",    "key" => "event_two", "matcher" => {"bus_event_type" => "event_two"}}}
+    describe '.from_redis' do
+      it 'should return from attributes' do
+        mult = { 'event_one' => { 'class' => 'MyClass', 'queue_name' => 'default', 'key' => 'event_one', 'matcher' => { 'bus_event_type' => 'event_one' } },
+                 'event_two' => { 'class' => 'MyClass', 'queue_name' => 'else', 'key' => 'event_two', 'matcher' => { 'bus_event_type' => 'event_two' } } }
 
         list = SubscriptionList.from_redis(mult)
         expect(list.size).to eq(2)
-        one = list.key("event_one")
-        two = list.key("event_two")
-        
-        expect(one.key).to eq("event_one")
-        expect(one.key).to eq("event_one")
-        expect(one.queue_name).to eq("default")
-        expect(one.class_name).to eq("MyClass")
-        expect(one.matcher.filters).to eq({"bus_event_type" => "event_one"})
-        
-        expect(two.key).to eq("event_two")
-        expect(two.key).to eq("event_two")
-        expect(two.queue_name).to eq("else")
-        expect(two.class_name).to eq("MyClass")
-        expect(two.matcher.filters).to eq({"bus_event_type" => "event_two"})
+        one = list.key('event_one')
+        two = list.key('event_two')
+
+        expect(one.key).to eq('event_one')
+        expect(one.key).to eq('event_one')
+        expect(one.queue_name).to eq('default')
+        expect(one.class_name).to eq('MyClass')
+        expect(one.matcher.filters).to eq('bus_event_type' => 'event_one')
+
+        expect(two.key).to eq('event_two')
+        expect(two.key).to eq('event_two')
+        expect(two.queue_name).to eq('else')
+        expect(two.class_name).to eq('MyClass')
+        expect(two.matcher.filters).to eq('bus_event_type' => 'event_two')
       end
     end
-    
-    describe "#to_redis" do
-      it "should generate what to store" do
+
+    describe '#to_redis' do
+      it 'should generate what to store' do
         list = SubscriptionList.new
-        list.add(Subscription.new("default", "key1", "MyClass", {"bus_event_type" => "event_one"}))
-        list.add(Subscription.new("else_ok", "key2", "MyClass", {"bus_event_type" => "event_two"}))
-        
+        list.add(Subscription.new('default', 'key1', 'MyClass', 'bus_event_type' => 'event_one'))
+        list.add(Subscription.new('else_ok', 'key2', 'MyClass', 'bus_event_type' => 'event_two'))
+
         hash = list.to_redis
-        expect(hash).to eq({  "key1" => {"queue_name" => "default", "key" => "key1", "class" => "MyClass", "matcher" => {"bus_event_type" => "event_one"}}, 
-                          "key2" => {"queue_name" => "else_ok", "key" => "key2", "class" => "MyClass", "matcher" => {"bus_event_type" => "event_two"}}
-                       })
-        
+        expect(hash).to eq('key1' => { 'queue_name' => 'default', 'key' => 'key1', 'class' => 'MyClass', 'matcher' => { 'bus_event_type' => 'event_one' } },
+                           'key2' => { 'queue_name' => 'else_ok', 'key' => 'key2', 'class' => 'MyClass', 'matcher' => { 'bus_event_type' => 'event_two' } })
       end
     end
   end

--- a/spec/subscription_spec.rb
+++ b/spec/subscription_spec.rb
@@ -1,53 +1,54 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module QueueBus
   describe Subscription do
-    it "should normalize the queue name" do
-      expect(Subscription.new("test",  "my_event", "MyClass", {}, nil).queue_name).to eq("test")
-      expect(Subscription.new("tes t", "my_event", "MyClass", {}, nil).queue_name).to eq("tes_t")
-      expect(Subscription.new("t%s",   "my_event", "MyClass", {}, nil).queue_name).to eq("t_s")
+    it 'should normalize the queue name' do
+      expect(Subscription.new('test',  'my_event', 'MyClass', {}, nil).queue_name).to eq('test')
+      expect(Subscription.new('tes t', 'my_event', 'MyClass', {}, nil).queue_name).to eq('tes_t')
+      expect(Subscription.new('t%s',   'my_event', 'MyClass', {}, nil).queue_name).to eq('t_s')
     end
-    
-    describe ".register" do
-      it "should take in args from dispatcher" do
-        executor = Proc.new { |attributes| }
-        sub = Subscription.register("queue_name", "mykey", "MyClass", {"bus_event_type" => "my_event"}, executor)
+
+    describe '.register' do
+      it 'should take in args from dispatcher' do
+        executor = proc { |attributes| }
+        sub = Subscription.register('queue_name', 'mykey', 'MyClass', { 'bus_event_type' => 'my_event' }, executor)
         expect(sub.send(:executor)).to eq(executor)
-        expect(sub.matcher.filters).to eq({"bus_event_type" => "my_event"})
-        expect(sub.queue_name).to eq("queue_name")
-        expect(sub.key).to eq("mykey")
-        expect(sub.class_name).to eq("MyClass")
+        expect(sub.matcher.filters).to eq('bus_event_type' => 'my_event')
+        expect(sub.queue_name).to eq('queue_name')
+        expect(sub.key).to eq('mykey')
+        expect(sub.class_name).to eq('MyClass')
       end
     end
-    
-    describe "#execute!" do
-      it "should call the executor with the attributes" do
+
+    describe '#execute!' do
+      it 'should call the executor with the attributes' do
         exec = Object.new
         expect(exec).to receive(:call)
-        
-        sub = Subscription.new("x", "y", "ClassName", {}, exec)
-        sub.execute!({"ok" => true})
+
+        sub = Subscription.new('x', 'y', 'ClassName', {}, exec)
+        sub.execute!('ok' => true)
       end
     end
-    
-    describe "#to_redis" do
-      it "should return what to store for this subscription" do
-        sub = Subscription.new("queue_one", "xyz", "ClassName", {"bus_event_type" => "my_event"}, nil)
-        expect(sub.to_redis).to eq({"queue_name" => "queue_one", "key" => "xyz", "class" => "ClassName", "matcher" => {"bus_event_type" => "my_event"}})
+
+    describe '#to_redis' do
+      it 'should return what to store for this subscription' do
+        sub = Subscription.new('queue_one', 'xyz', 'ClassName', { 'bus_event_type' => 'my_event' }, nil)
+        expect(sub.to_redis).to eq('queue_name' => 'queue_one', 'key' => 'xyz', 'class' => 'ClassName', 'matcher' => { 'bus_event_type' => 'my_event' })
       end
     end
-    
-    describe "#matches?" do
-      it "should do pattern stuff" do
-        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one"}).matches?("bus_event_type" => "one")).to eq(true)
-        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one"}).matches?("bus_event_type" => "onex")).to eq(false)
-        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "^one.*$"}).matches?("bus_event_type" => "onex")).to eq(true)
-        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one.*"}).matches?("bus_event_type" => "onex")).to eq(true)
-        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one.?"}).matches?("bus_event_type" => "onex")).to eq(true)
-        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one.?"}).matches?("bus_event_type" => "one")).to eq(true)
-        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "\\"}).matches?("bus_event_type" => "one")).to eq(false)
+
+    describe '#matches?' do
+      it 'should do pattern stuff' do
+        expect(Subscription.new('x', 'id', 'ClassName', 'bus_event_type' => 'one').matches?('bus_event_type' => 'one')).to eq(true)
+        expect(Subscription.new('x', 'id', 'ClassName', 'bus_event_type' => 'one').matches?('bus_event_type' => 'onex')).to eq(false)
+        expect(Subscription.new('x', 'id', 'ClassName', 'bus_event_type' => '^one.*$').matches?('bus_event_type' => 'onex')).to eq(true)
+        expect(Subscription.new('x', 'id', 'ClassName', 'bus_event_type' => 'one.*').matches?('bus_event_type' => 'onex')).to eq(true)
+        expect(Subscription.new('x', 'id', 'ClassName', 'bus_event_type' => 'one.?').matches?('bus_event_type' => 'onex')).to eq(true)
+        expect(Subscription.new('x', 'id', 'ClassName', 'bus_event_type' => 'one.?').matches?('bus_event_type' => 'one')).to eq(true)
+        expect(Subscription.new('x', 'id', 'ClassName', 'bus_event_type' => '\\').matches?('bus_event_type' => 'one')).to eq(false)
       end
     end
-    
   end
 end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -1,31 +1,33 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module QueueBus
   describe Worker do
-    it "should proxy to given class" do
-      hash = {"bus_class_proxy" => "QueueBus::Driver", "ok" => true}
+    it 'should proxy to given class' do
+      hash = { 'bus_class_proxy' => 'QueueBus::Driver', 'ok' => true }
       expect(QueueBus::Driver).to receive(:perform).with(hash)
       QueueBus::Worker.perform(JSON.generate(hash))
     end
 
-    it "should use instance" do
-      hash = {"bus_class_proxy" => "QueueBus::Rider", "ok" => true}
+    it 'should use instance' do
+      hash = { 'bus_class_proxy' => 'QueueBus::Rider', 'ok' => true }
       expect(QueueBus::Rider).to receive(:perform).with(hash)
       QueueBus::Worker.new.perform(JSON.generate(hash))
     end
 
-    it "should not freak out if class not there anymore" do
-      hash = {"bus_class_proxy" => "QueueBus::BadClass", "ok" => true}
+    it 'should not freak out if class not there anymore' do
+      hash = { 'bus_class_proxy' => 'QueueBus::BadClass', 'ok' => true }
 
       expect(QueueBus::Worker.perform(JSON.generate(hash))).to eq(nil)
     end
 
-    it "should raise error if proxy raises error" do
-      hash = {"bus_class_proxy" => "QueueBus::Rider", "ok" => true}
-      expect(QueueBus::Rider).to receive(:perform).with(hash).and_raise("rider crash")
-      expect {
+    it 'should raise error if proxy raises error' do
+      hash = { 'bus_class_proxy' => 'QueueBus::Rider', 'ok' => true }
+      expect(QueueBus::Rider).to receive(:perform).with(hash).and_raise('rider crash')
+      expect do
         QueueBus::Worker.perform(JSON.generate(hash))
-      }.to raise_error("rider crash")
+      end.to raise_error('rider crash')
     end
   end
 end


### PR DESCRIPTION
This change resolves an issue of multiple heartbeats firing within the same minute. It does so by switching to using the `cron` syntax instead of the `every` syntax.

In addition, this applies rubocop autocorrect linting to the spec files and lib files. These are in separate commits for easier review.