### PR TITLE
Allow sidekiq 6.x

### DIFF
--- a/sidekiq-bus.gemspec
+++ b/sidekiq-bus.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('queue-bus', ['>= 0.7', '< 1'])
-  s.add_dependency('sidekiq', ['>= 3.0.0', '~> 5.0'])
+  s.add_dependency('sidekiq', ['>= 3.0.0', '~> 6.0'])
   s.add_dependency('sidekiq-scheduler', '~> 3.0')
 
   s.add_development_dependency("rspec")


### PR DESCRIPTION
This superficially seems to work, I don't see where this would cause any compatibility issues. In addition, this effectively patches a few high-risk Sidekiq vulnerabilities, for any applications that still use this gem (like ours). 