### PR TITLE
Test against a real redis database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- [Development] Discontinues use of FakeRedis in favor of real Redis for testing.
+
 ## [1.1.0] - 2025-05-13
 
 ### Changed

--- a/README.mdown
+++ b/README.mdown
@@ -162,6 +162,22 @@ event to the appropriate code block.
 You can also say `QueueBus.local_mode = :suppress` to turn off publishing altogether.
 This can be helpful inside some sort of migration, for example.
 
+### Development
+
+#### Running Tests
+
+The test suite requires a Redis instance. For convenience, we provide Docker Compose configuration to run Redis in a container:
+
+```bash
+docker-compose up -d
+
+bundle exec rspec
+```
+
+The test suite uses database 15 by default to avoid conflicts with your development Redis data.
+
+You can override the connection string (including the database number) by setting the `REDIS_URL` environment variable.
+
 ### TODO
 
 * Replace local modes with adapters

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  redis_data:

--- a/sidekiq-bus.gemspec
+++ b/sidekiq-bus.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency('sidekiq-scheduler', ['>= 3.0', '< 5.0'])
 
   s.add_development_dependency("rspec")
-  s.add_development_dependency("fakeredis")
   s.add_development_dependency("redis-namespace")
   s.add_development_dependency("pry")
   s.add_development_dependency("timecop")

--- a/spec/adapter/integration_spec.rb
+++ b/spec/adapter/integration_spec.rb
@@ -87,9 +87,6 @@ describe 'Sidekiq Integration' do
       val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }
       expect(val).to eq(nil) # nothing really added
 
-      # NOTE: this is silently invoking a monkey patch in spec_helper
-      # since the Poller invokes a Lua script that FakeRedis does not
-      # natively support.
       Sidekiq::Scheduled::Poller.new(Sidekiq).enqueue
 
       val = QueueBus.redis { |redis| redis.lpop('queue:bus_incoming') }


### PR DESCRIPTION
Because Sidekiq no longer allows injection of a connection pool after version 6, continuing to use the FakeRedis gem in the test suite is not practical. Docker has made this sort of thing truly trivial in the time since this was first set up however, so go with the simple solution and run the test suite in an environment that requires substantially less mocking and hand-waving.