### PR TITLE
Require a user-provided Redis pool to replace Sidekiq.redis

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -11,6 +11,27 @@ To install, include the 'sidekiq-bus' gem and add the following to your Rakefile
 require "sidekiq_bus/tasks"
 ```
 
+### Configure
+Starting from version 7, Sidekiq no longer provides a standard Redis connection pool, instead providing a limited
+wrapper around the low-level RedisClient gem. To maintain compatibility with both QueueBus and later versions of
+Sidekiq, SidekiqBus now requires an explicit Redis handler. To preserve your existing QueueBus data, this handler should
+connect to the same Redis instance and database as your Sidekiq configuration.
+
+The handler can be any object that responds to `call` and yields a Redis connection. In an initializer, set it with:
+
+```ruby
+  # Naive example
+  SidekiqBus.redis_handler = ->(&block) { block.call(Redis.new(my_config) }
+
+  # More typical example using the Redis-recommended ConnectionPool gem
+  pool = ConnectionPool.new(size: pool_size, timeout: pool_timeout) { Redis.new(my_config) }
+  SidekiqBus.redis_handler = pool.method(:with).to_proc
+  # Or, for clarity:
+  SidekiqBus.redis_handler = ->(&block) do
+    pool.with { |redis| block.call(redis) }
+  end
+```
+
 ### Example
 
 Application A can publish an event

--- a/lib/sidekiq_bus/adapter.rb
+++ b/lib/sidekiq_bus/adapter.rb
@@ -21,7 +21,7 @@ module QueueBus
       end
 
       def redis(&block)
-        ::Sidekiq.redis(&block)
+        ::SidekiqBus.redis(&block)
       end
 
       def enqueue(queue_name, klass, hash)

--- a/sidekiq-bus.gemspec
+++ b/sidekiq-bus.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('queue-bus', ['>= 0.7', '< 1'])
   s.add_dependency('sidekiq', ['>= 3.0.0', '< 7.0'])
+  s.add_dependency('redis', ['>= 4.0', '< 6.0'])
   s.add_dependency('rack', "< 3.0") # Sidekiq 6 was sunset before Rack 3.0 and does not support it
   s.add_dependency('sidekiq-scheduler', ['>= 3.0', '< 5.0'])
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,9 @@ rescue => e
   exit 1
 end
 
-Sidekiq.redis = ConnectionPool.new { Redis.new(url: redis_url) }
+redis_pool = ConnectionPool.new { Redis.new(url: redis_url) }
+Sidekiq.redis = redis_pool
+SidekiqBus.redis_handler = redis_pool.method(:with).to_proc
 
 require 'fileutils'
 


### PR DESCRIPTION
Sidekiq 7 does not provide a standard Redis connection, instead using a custom wrapper around the low-level RedisClient gem that does not offer explicit support for all of the method calls used by QueueBus. This can introduce subtle errors, e.g. methods that return boolean values from Redis will return integer 0 or 1 from RedisClient. To ensure compatibility, SidekiqBus must now be provided with a Redis connection explicitly. See the `Configure` section of the README for more details.