### PR TITLE
Force-reload SidekiqScheduler when dynamic schedules are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [2.0.0] - 2025-06-25
+
+### Fixed 
+- Properly installs the QueueBus heartbeat when SidekiqSchedule is not run in dynamic mode. 
+
 ## [2.0.0] - 2025-06-17
 
 - [BREAKING] Sidekiq major version now targets 7.X

--- a/lib/sidekiq_bus/adapter.rb
+++ b/lib/sidekiq_bus/adapter.rb
@@ -67,7 +67,13 @@ module QueueBus
         )
 
         # If dynamic is enabled, this will propagate through a different mechanism
-        SidekiqScheduler::Scheduler.instance.reload_schedule! unless ::Sidekiq::Scheduler.instance.dynamic
+        unless ::Sidekiq::Scheduler.instance.dynamic
+          # despite the docs for SidekiqScheduler, the above entry doesn't hit the memory store until we reload from
+          # the redis store:
+          ::Sidekiq.reload_schedule!
+          # this then allows the updated schedule to be applied:
+          SidekiqScheduler::Scheduler.instance.reload_schedule!
+        end
       end
     end
   end

--- a/lib/sidekiq_bus/version.rb
+++ b/lib/sidekiq_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqBus
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end


### PR DESCRIPTION
When running with dynamic:false, SidekiqScheduler supposedly allows a
manual reload of the scheduler after a `set_schedule` with a single
reload command; but that command just re-applies the schedule currently
in memory, not the schedule in Redis modified by `set_schedule`. Load
the schedule from Redis into memory before re-applying it to get the
heartbeat to actually initialize properly.