### PR TITLE
Add Sidekiq 8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [3.0.0] - 2026-06-05
+
+### Changed
+- [BREAKING] Sidekiq dependency now allows Sidekiq 8.X (still supports 7.3+).
+- [BREAKING] SidekiqScheduler dependency now allows 6.X to support Sidekiq 8.
+- Web UI registration migrated to Sidekiq::Web.configure block with explicit
+  name:, tab:, and index: keyword arguments, which are required by Sidekiq 8.
+  The same syntax is forward-compatible with Sidekiq 7.
+
 ## [2.0.0] - 2025-06-25
 
 ### Fixed 

--- a/lib/sidekiq_bus/server.rb
+++ b/lib/sidekiq_bus/server.rb
@@ -134,6 +134,7 @@ module SidekiqBus
   end
 end
 
-Sidekiq::Web.register SidekiqBus::Server
-Sidekiq::Web.locales << File.expand_path(File.dirname(__FILE__) + "/web/locales")
-Sidekiq::Web.tabs['Bus'] = 'bus'
+Sidekiq::Web.configure do |cfg|
+  cfg.register(SidekiqBus::Server, name: 'sidekiq_bus', tab: 'Bus', index: 'bus')
+  cfg.locales << File.expand_path(File.dirname(__FILE__) + "/web/locales")
+end

--- a/lib/sidekiq_bus/version.rb
+++ b/lib/sidekiq_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqBus
-  VERSION = '2.0.1'
+  VERSION = '3.0.0'
 end

--- a/sidekiq-bus.gemspec
+++ b/sidekiq-bus.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency('queue-bus', ['>= 0.7', '< 1'])
   s.add_dependency('redis', ['>= 4.0', '< 6.0'])
-  s.add_dependency('sidekiq', ['>= 7.0.0', '< 8.0'])
-  s.add_dependency('sidekiq-scheduler', ['>= 5.0', '< 6.0'])
+  s.add_dependency('sidekiq', ['>= 7.3', '< 9.0'])
+  s.add_dependency('sidekiq-scheduler', ['>= 5.0', '< 7.0'])
 
   s.add_development_dependency("rspec")
   s.add_development_dependency("pry")


### PR DESCRIPTION
## Problem

`sidekiq-bus` v2.0.1 pins `sidekiq >= 7.0.0, < 8.0`, which prevents dependent applications from upgrading to Sidekiq 8.

In Sidekiq 8, `Sidekiq::Web` was rebuilt on Rack 3 and the positional `Sidekiq::Web.register` API was removed in favor of a keyword-argument-based `Sidekiq::Web.configure` block (introduced in Sidekiq 7.3). As a result, the current Web UI integration also breaks at load time on Sidekiq 8.

## Solution

- Bump `sidekiq` dependency to `>= 7.3, < 9.0`. Minimum is raised to 7.3 because the new `Sidekiq::Web.configure` block API was introduced in that release; this lets us use a single integration path that works for both Sidekiq 7.3+ and Sidekiq 8.
- Bump `sidekiq-scheduler` dependency to `>= 5.0, < 7.0` (6.0.2 already supports Sidekiq 8).
- Migrate `lib/sidekiq_bus/server.rb` to use `Sidekiq::Web.configure do |cfg|`, registering `SidekiqBus::Server` with explicit `name:`, `tab:`, and `index:` keyword arguments (required by Sidekiq 8, forward-compatible with Sidekiq 7.3+).
- Bump version to `3.0.0` and update `CHANGELOG.md`.

Middleware (`lib/sidekiq_bus/middleware/retry.rb`), adapter (`lib/sidekiq_bus/adapter.rb`), and scheduler hooks did not require changes — they continue to satisfy the Sidekiq 8 middleware/server contract.

The `redis` runtime dependency is left unchanged: `sidekiq-bus` itself does not invoke `redis-rb` directly (the user-supplied `redis_handler` owns the connection), but `queue-bus` still declares it transitively, and the existing `>= 4.0, < 6.0` constraint resolves cleanly alongside Sidekiq 8.

## Steps to test

1. `bundle install` against Sidekiq 8: pulls in `sidekiq 8.1.6`, `sidekiq-scheduler 6.0.2`.
2. `bundle exec rspec` — full suite passes (108 examples, 0 failures, 1 pre-existing pending).
3. Verified backward compatibility with Sidekiq 7.3 by pinning via a scratch Gemfile (`gem 'sidekiq', '~> 7.3'`, `gem 'sidekiq-scheduler', '~> 5.0'`): `sidekiq 7.3.9`, `sidekiq-scheduler 5.0.6`, full suite passes (108 examples, 0 failures).

## Breaking changes

- Minimum Sidekiq version raised from 7.0 to 7.3 (required to use the `Sidekiq::Web.configure` block API on a single code path).
- Web UI registration uses the new kwargs API; any host application that integrates with the bus tab via Sidekiq::Web should continue to work transparently.

## References

- Sidekiq 8.0 upgrade notes: https://github.com/sidekiq/sidekiq/blob/main/docs/8.0-Upgrade.md
- Prior Sidekiq 7 compatibility PR (precedent): #31


